### PR TITLE
update uncrustify config to reflect google code style

### DIFF
--- a/ament_uncrustify/ament_code_style.cfg
+++ b/ament_uncrustify/ament_code_style.cfg
@@ -39,7 +39,7 @@ utf8_force                               = false    # false/true
 
 # The number of columns to indent per level.
 # Usually 2, 3, 4, or 8.
-indent_columns                           = 8        # number
+indent_columns                           = 2        # number
 
 # The continuation indent. If non-zero, this overrides the indent of '(' and '=' continuation indents.
 # For FreeBSD, this is set to 4.
@@ -49,7 +49,7 @@ indent_continue                          = 0        # number
 # 0=spaces only
 # 1=indent with tabs to brace level, align with spaces
 # 2=indent and align with tabs, using spaces when not on a tabstop
-indent_with_tabs                         = 1        # number
+indent_with_tabs                         = 0        # number
 
 # Comments that are not a brace level are indented with tabs on a tabstop.
 # Requires indent_with_tabs=2. If false, will use spaces.
@@ -94,13 +94,13 @@ indent_namespace_limit                   = 0        # number
 indent_extern                            = false    # false/true
 
 # Whether the 'class' body is indented
-indent_class                             = false    # false/true
+indent_class                             = true     # false/true
 
 # Whether to indent the stuff after a leading class colon
 indent_class_colon                       = false    # false/true
 
 # Additional indenting for constructor initializer list
-indent_ctor_init                         = 0        # number
+indent_ctor_init                         = 2        # number
 
 # False=treat 'else\nif' as 'else if' for indenting purposes
 # True=indent the 'if' one level
@@ -153,7 +153,7 @@ indent_relative_single_line_comments     = false    # false/true
 
 # Spaces to indent 'case' from 'switch'
 # Usually 0 or indent_columns.
-indent_switch_case                       = 0        # number
+indent_switch_case                       = 2        # number
 
 # Spaces to shift the 'case' line, without affecting any other lines
 # Usually 0.
@@ -212,10 +212,10 @@ indent_align_assign                      = true     # false/true
 #
 
 # Add or remove space around arithmetic operator '+', '-', '/', '*', etc
-sp_arith                                 = ignore   # ignore/add/remove/force
+sp_arith                                 = force    # ignore/add/remove/force
 
 # Add or remove space around assignment operator '=', '+=', etc
-sp_assign                                = ignore   # ignore/add/remove/force
+sp_assign                                = force    # ignore/add/remove/force
 
 # Add or remove space around assignment operator '=' in a prototype
 sp_assign_default                        = ignore   # ignore/add/remove/force
@@ -242,10 +242,10 @@ sp_pp_concat                             = add      # ignore/add/remove/force
 sp_pp_stringify                          = add      # ignore/add/remove/force
 
 # Add or remove space around boolean operators '&&' and '||'
-sp_bool                                  = ignore   # ignore/add/remove/force
+sp_bool                                  = force    # ignore/add/remove/force
 
 # Add or remove space around compare operator '<', '>', '==', etc
-sp_compare                               = ignore   # ignore/add/remove/force
+sp_compare                               = force    # ignore/add/remove/force
 
 # Add or remove space inside '(' and ')'
 sp_inside_paren                          = ignore   # ignore/add/remove/force
@@ -257,7 +257,7 @@ sp_paren_paren                           = ignore   # ignore/add/remove/force
 sp_balance_nested_parens                 = false    # false/true
 
 # Add or remove space between ')' and '{'
-sp_paren_brace                           = ignore   # ignore/add/remove/force
+sp_paren_brace                           = force    # ignore/add/remove/force
 
 # Add or remove space before pointer star '*'
 sp_before_ptr_star                       = ignore   # ignore/add/remove/force
@@ -302,28 +302,28 @@ sp_after_type                            = force    # ignore/add/remove/force
 sp_template_angle                        = ignore   # ignore/add/remove/force
 
 # Add or remove space before '<>'
-sp_before_angle                          = ignore   # ignore/add/remove/force
+sp_before_angle                          = remove   # ignore/add/remove/force
 
 # Add or remove space inside '<' and '>'
-sp_inside_angle                          = ignore   # ignore/add/remove/force
+sp_inside_angle                          = remove   # ignore/add/remove/force
 
 # Add or remove space after '<>'
-sp_after_angle                           = ignore   # ignore/add/remove/force
+sp_after_angle                           = remove   # ignore/add/remove/force
 
 # Add or remove space between '<>' and '(' as found in 'new List<byte>();'
-sp_angle_paren                           = ignore   # ignore/add/remove/force
+sp_angle_paren                           = remove   # ignore/add/remove/force
 
 # Add or remove space between '<>' and a word as in 'List<byte> m;'
-sp_angle_word                            = ignore   # ignore/add/remove/force
+sp_angle_word                            = force    # ignore/add/remove/force
 
 # Add or remove space between '>' and '>' in '>>' (template stuff C++/C# only). Default=Add
-sp_angle_shift                           = add      # ignore/add/remove/force
+sp_angle_shift                           = ignore   # ignore/add/remove/force
 
 # Add or remove space before '(' of 'if', 'for', 'switch', and 'while'
-sp_before_sparen                         = ignore   # ignore/add/remove/force
+sp_before_sparen                         = force    # ignore/add/remove/force
 
 # Add or remove space inside if-condition '(' and ')'
-sp_inside_sparen                         = ignore   # ignore/add/remove/force
+sp_inside_sparen                         = remove   # ignore/add/remove/force
 
 # Add or remove space before if-condition ')'. Overrides sp_inside_sparen.
 sp_inside_sparen_close                   = ignore   # ignore/add/remove/force
@@ -332,7 +332,7 @@ sp_inside_sparen_close                   = ignore   # ignore/add/remove/force
 sp_after_sparen                          = ignore   # ignore/add/remove/force
 
 # Add or remove space between ')' and '{' of 'if', 'for', 'switch', and 'while'
-sp_sparen_brace                          = ignore   # ignore/add/remove/force
+sp_sparen_brace                          = force    # ignore/add/remove/force
 
 # Add or remove space between 'invariant' and '(' in the D language.
 sp_invariant_paren                       = ignore   # ignore/add/remove/force
@@ -362,16 +362,16 @@ sp_after_semi_for                        = force    # ignore/add/remove/force
 sp_after_semi_for_empty                  = ignore   # ignore/add/remove/force
 
 # Add or remove space before '[' (except '[]')
-sp_before_square                         = ignore   # ignore/add/remove/force
+sp_before_square                         = remove   # ignore/add/remove/force
 
 # Add or remove space before '[]'
-sp_before_squares                        = ignore   # ignore/add/remove/force
+sp_before_squares                        = remove   # ignore/add/remove/force
 
 # Add or remove space inside a non-empty '[' and ']'
-sp_inside_square                         = ignore   # ignore/add/remove/force
+sp_inside_square                         = remove   # ignore/add/remove/force
 
 # Add or remove space after ','
-sp_after_comma                           = ignore   # ignore/add/remove/force
+sp_after_comma                           = force    # ignore/add/remove/force
 
 # Add or remove space before ','
 sp_before_comma                          = remove   # ignore/add/remove/force
@@ -383,31 +383,31 @@ sp_paren_comma                           = force    # ignore/add/remove/force
 sp_before_ellipsis                       = ignore   # ignore/add/remove/force
 
 # Add or remove space after class ':'
-sp_after_class_colon                     = ignore   # ignore/add/remove/force
+sp_after_class_colon                     = force    # ignore/add/remove/force
 
 # Add or remove space before class ':'
-sp_before_class_colon                    = ignore   # ignore/add/remove/force
+sp_before_class_colon                    = force    # ignore/add/remove/force
 
 # Add or remove space before case ':'. Default=Remove
 sp_before_case_colon                     = remove   # ignore/add/remove/force
 
 # Add or remove space between 'operator' and operator sign
-sp_after_operator                        = ignore   # ignore/add/remove/force
+sp_after_operator                        = remove   # ignore/add/remove/force
 
 # Add or remove space between the operator symbol and the open paren, as in 'operator ++('
-sp_after_operator_sym                    = ignore   # ignore/add/remove/force
+sp_after_operator_sym                    = remove   # ignore/add/remove/force
 
 # Add or remove space after C/D cast, i.e. 'cast(int)a' vs 'cast(int) a' or '(int)a' vs '(int) a'
 sp_after_cast                            = ignore   # ignore/add/remove/force
 
 # Add or remove spaces inside cast parens
-sp_inside_paren_cast                     = ignore   # ignore/add/remove/force
+sp_inside_paren_cast                     = remove   # ignore/add/remove/force
 
 # Add or remove space between the type and open paren in a C++ cast, i.e. 'int(exp)' vs 'int (exp)'
-sp_cpp_cast_paren                        = ignore   # ignore/add/remove/force
+sp_cpp_cast_paren                        = remove   # ignore/add/remove/force
 
 # Add or remove space between 'sizeof' and '('
-sp_sizeof_paren                          = ignore   # ignore/add/remove/force
+sp_sizeof_paren                          = remove   # ignore/add/remove/force
 
 # Add or remove space after the tag keyword (Pawn)
 sp_after_tag                             = ignore   # ignore/add/remove/force
@@ -419,35 +419,35 @@ sp_inside_braces_enum                    = ignore   # ignore/add/remove/force
 sp_inside_braces_struct                  = ignore   # ignore/add/remove/force
 
 # Add or remove space inside '{' and '}'
-sp_inside_braces                         = ignore   # ignore/add/remove/force
+sp_inside_braces                         = remove   # ignore/add/remove/force
 
 # Add or remove space inside '{}'
-sp_inside_braces_empty                   = ignore   # ignore/add/remove/force
+sp_inside_braces_empty                   = remove   # ignore/add/remove/force
 
 # Add or remove space between return type and function name
 # A minimum of 1 is forced except for pointer return types.
 sp_type_func                             = ignore   # ignore/add/remove/force
 
 # Add or remove space between function name and '(' on function declaration
-sp_func_proto_paren                      = ignore   # ignore/add/remove/force
+sp_func_proto_paren                      = remove   # ignore/add/remove/force
 
 # Add or remove space between function name and '(' on function definition
-sp_func_def_paren                        = ignore   # ignore/add/remove/force
+sp_func_def_paren                        = remove   # ignore/add/remove/force
 
 # Add or remove space inside empty function '()'
-sp_inside_fparens                        = ignore   # ignore/add/remove/force
+sp_inside_fparens                        = remove   # ignore/add/remove/force
 
 # Add or remove space inside function '(' and ')'
-sp_inside_fparen                         = ignore   # ignore/add/remove/force
+sp_inside_fparen                         = remove   # ignore/add/remove/force
 
 # Add or remove space between ']' and '(' when part of a function call.
-sp_square_fparen                         = ignore   # ignore/add/remove/force
+sp_square_fparen                         = remove   # ignore/add/remove/force
 
 # Add or remove space between ')' and '{' of function
-sp_fparen_brace                          = ignore   # ignore/add/remove/force
+sp_fparen_brace                          = force    # ignore/add/remove/force
 
 # Add or remove space between function name and '(' on function calls
-sp_func_call_paren                       = ignore   # ignore/add/remove/force
+sp_func_call_paren                       = remove   # ignore/add/remove/force
 
 # Add or remove space between function name and '()' on function calls without parameters.
 # If set to 'ignore' (the default), sp_func_call_paren is used.
@@ -458,7 +458,7 @@ sp_func_call_paren_empty                 = ignore   # ignore/add/remove/force
 sp_func_call_user_paren                  = ignore   # ignore/add/remove/force
 
 # Add or remove space between a constructor/destructor and the open paren
-sp_func_class_paren                      = ignore   # ignore/add/remove/force
+sp_func_class_paren                      = remove   # ignore/add/remove/force
 
 # Add or remove space between 'return' and '('
 sp_return_paren                          = ignore   # ignore/add/remove/force
@@ -491,25 +491,25 @@ sp_macro                                 = ignore   # ignore/add/remove/force
 sp_macro_func                            = ignore   # ignore/add/remove/force
 
 # Add or remove space between 'else' and '{' if on the same line
-sp_else_brace                            = ignore   # ignore/add/remove/force
+sp_else_brace                            = force    # ignore/add/remove/force
 
 # Add or remove space between '}' and 'else' if on the same line
-sp_brace_else                            = ignore   # ignore/add/remove/force
+sp_brace_else                            = force    # ignore/add/remove/force
 
 # Add or remove space between '}' and the name of a typedef on the same line
-sp_brace_typedef                         = ignore   # ignore/add/remove/force
+sp_brace_typedef                         = force    # ignore/add/remove/force
 
 # Add or remove space between 'catch' and '{' if on the same line
-sp_catch_brace                           = ignore   # ignore/add/remove/force
+sp_catch_brace                           = force    # ignore/add/remove/force
 
 # Add or remove space between '}' and 'catch' if on the same line
-sp_brace_catch                           = ignore   # ignore/add/remove/force
+sp_brace_catch                           = force    # ignore/add/remove/force
 
 # Add or remove space between 'finally' and '{' if on the same line
-sp_finally_brace                         = ignore   # ignore/add/remove/force
+sp_finally_brace                         = force    # ignore/add/remove/force
 
 # Add or remove space between '}' and 'finally' if on the same line
-sp_brace_finally                         = ignore   # ignore/add/remove/force
+sp_brace_finally                         = force    # ignore/add/remove/force
 
 # Add or remove space between 'try' and '{' if on the same line
 sp_try_brace                             = ignore   # ignore/add/remove/force
@@ -518,10 +518,10 @@ sp_try_brace                             = ignore   # ignore/add/remove/force
 sp_getset_brace                          = ignore   # ignore/add/remove/force
 
 # Add or remove space before the '::' operator
-sp_before_dc                             = ignore   # ignore/add/remove/force
+sp_before_dc                             = remove   # ignore/add/remove/force
 
 # Add or remove space after the '::' operator
-sp_after_dc                              = ignore   # ignore/add/remove/force
+sp_after_dc                              = remove   # ignore/add/remove/force
 
 # Add or remove around the D named array initializer ':' operator
 sp_d_array_colon                         = ignore   # ignore/add/remove/force
@@ -602,10 +602,10 @@ sp_before_oc_block_caret                 = ignore   # ignore/add/remove/force
 sp_after_oc_block_caret                  = ignore   # ignore/add/remove/force
 
 # Add or remove space around the ':' in 'b ? t : f'
-sp_cond_colon                            = ignore   # ignore/add/remove/force
+sp_cond_colon                            = force    # ignore/add/remove/force
 
 # Add or remove space around the '?' in 'b ? t : f'
-sp_cond_question                         = ignore   # ignore/add/remove/force
+sp_cond_question                         = force    # ignore/add/remove/force
 
 # Fix the spacing between 'case' and the label. Only 'ignore' and 'force' make sense here.
 sp_case_label                            = ignore   # ignore/add/remove/force
@@ -626,7 +626,7 @@ sp_after_new                             = ignore   # ignore/add/remove/force
 sp_before_tr_emb_cmt                     = ignore   # ignore/add/remove/force
 
 # Number of spaces before a trailing or embedded comment
-sp_num_before_tr_emb_cmt                 = 0        # number
+sp_num_before_tr_emb_cmt                 = 2        # number
 
 #
 # Code alignment (not left column spaces/tabs)
@@ -792,37 +792,37 @@ align_oc_decl_colon                      = false    # false/true
 #
 
 # Whether to collapse empty blocks between '{' and '}'
-nl_collapse_empty_body                   = false    # false/true
+nl_collapse_empty_body                   = true     # false/true
 
 # Don't split one-line braced assignments - 'foo_t f = { 1, 2 };'
-nl_assign_leave_one_liners               = false    # false/true
+nl_assign_leave_one_liners               = true     # false/true
 
 # Don't split one-line braced statements inside a class xx { } body
-nl_class_leave_one_liners                = false    # false/true
+nl_class_leave_one_liners                = true     # false/true
 
 # Don't split one-line enums: 'enum foo { BAR = 15 };'
-nl_enum_leave_one_liners                 = false    # false/true
+nl_enum_leave_one_liners                 = true     # false/true
 
 # Don't split one-line get or set functions
-nl_getset_leave_one_liners               = false    # false/true
+nl_getset_leave_one_liners               = true     # false/true
 
 # Don't split one-line function definitions - 'int foo() { return 0; }'
-nl_func_leave_one_liners                 = false    # false/true
+nl_func_leave_one_liners                 = true     # false/true
 
 # Don't split one-line if/else statements - 'if(a) b++;'
-nl_if_leave_one_liners                   = false    # false/true
+nl_if_leave_one_liners                   = true     # false/true
 
 # Add or remove newlines at the start of the file
-nl_start_of_file                         = ignore   # ignore/add/remove/force
+nl_start_of_file                         = remove   # ignore/add/remove/force
 
 # The number of newlines at the start of the file (only used if nl_start_of_file is 'add' or 'force'
 nl_start_of_file_min                     = 0        # number
 
 # Add or remove newline at the end of the file
-nl_end_of_file                           = ignore   # ignore/add/remove/force
+nl_end_of_file                           = force    # ignore/add/remove/force
 
 # The number of newlines at the end of the file (only used if nl_end_of_file is 'add' or 'force')
-nl_end_of_file_min                       = 0        # number
+nl_end_of_file_min                       = 1        # number
 
 # Add or remove newline between '=' and '{'
 nl_assign_brace                          = ignore   # ignore/add/remove/force
@@ -839,56 +839,56 @@ nl_func_var_def_blk                      = 0        # number
 
 # Add or remove newline between a function call's ')' and '{', as in:
 # list_for_each(item, &list) { }
-nl_fcall_brace                           = ignore   # ignore/add/remove/force
+nl_fcall_brace                           = remove   # ignore/add/remove/force
 
 # Add or remove newline between 'enum' and '{'
-nl_enum_brace                            = ignore   # ignore/add/remove/force
+nl_enum_brace                            = remove   # ignore/add/remove/force
 
 # Add or remove newline between 'struct and '{'
-nl_struct_brace                          = ignore   # ignore/add/remove/force
+nl_struct_brace                          = remove   # ignore/add/remove/force
 
 # Add or remove newline between 'union' and '{'
-nl_union_brace                           = ignore   # ignore/add/remove/force
+nl_union_brace                           = remove   # ignore/add/remove/force
 
 # Add or remove newline between 'if' and '{'
-nl_if_brace                              = ignore   # ignore/add/remove/force
+nl_if_brace                              = remove   # ignore/add/remove/force
 
 # Add or remove newline between '}' and 'else'
-nl_brace_else                            = ignore   # ignore/add/remove/force
+nl_brace_else                            = remove   # ignore/add/remove/force
 
 # Add or remove newline between 'else if' and '{'
 # If set to ignore, nl_if_brace is used instead
 nl_elseif_brace                          = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'else' and '{'
-nl_else_brace                            = ignore   # ignore/add/remove/force
+nl_else_brace                            = remove   # ignore/add/remove/force
 
 # Add or remove newline between 'else' and 'if'
-nl_else_if                               = ignore   # ignore/add/remove/force
+nl_else_if                               = remove   # ignore/add/remove/force
 
 # Add or remove newline between '}' and 'finally'
-nl_brace_finally                         = ignore   # ignore/add/remove/force
+nl_brace_finally                         = remove   # ignore/add/remove/force
 
 # Add or remove newline between 'finally' and '{'
-nl_finally_brace                         = ignore   # ignore/add/remove/force
+nl_finally_brace                         = remove   # ignore/add/remove/force
 
 # Add or remove newline between 'try' and '{'
-nl_try_brace                             = ignore   # ignore/add/remove/force
+nl_try_brace                             = remove   # ignore/add/remove/force
 
 # Add or remove newline between get/set and '{'
 nl_getset_brace                          = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'for' and '{'
-nl_for_brace                             = ignore   # ignore/add/remove/force
+nl_for_brace                             = remove   # ignore/add/remove/force
 
 # Add or remove newline between 'catch' and '{'
-nl_catch_brace                           = ignore   # ignore/add/remove/force
+nl_catch_brace                           = remove   # ignore/add/remove/force
 
 # Add or remove newline between '}' and 'catch'
-nl_brace_catch                           = ignore   # ignore/add/remove/force
+nl_brace_catch                           = remove   # ignore/add/remove/force
 
 # Add or remove newline between 'while' and '{'
-nl_while_brace                           = ignore   # ignore/add/remove/force
+nl_while_brace                           = remove   # ignore/add/remove/force
 
 # Add or remove newline between 'using' and '{'
 nl_using_brace                           = ignore   # ignore/add/remove/force
@@ -898,13 +898,13 @@ nl_using_brace                           = ignore   # ignore/add/remove/force
 nl_brace_brace                           = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'do' and '{'
-nl_do_brace                              = ignore   # ignore/add/remove/force
+nl_do_brace                              = remove   # ignore/add/remove/force
 
 # Add or remove newline between '}' and 'while' of 'do' statement
-nl_brace_while                           = ignore   # ignore/add/remove/force
+nl_brace_while                           = remove   # ignore/add/remove/force
 
 # Add or remove newline between 'switch' and '{'
-nl_switch_brace                          = ignore   # ignore/add/remove/force
+nl_switch_brace                          = remove   # ignore/add/remove/force
 
 # Add a newline between ')' and '{' if the ')' is on a different line than the if/for/etc.
 # Overrides nl_for_brace, nl_if_brace, nl_switch_brace, nl_while_switch, and nl_catch_brace.
@@ -926,13 +926,13 @@ nl_after_case                            = false    # false/true
 nl_case_colon_brace                      = ignore   # ignore/add/remove/force
 
 # Newline between namespace and {
-nl_namespace_brace                       = ignore   # ignore/add/remove/force
+nl_namespace_brace                       = remove   # ignore/add/remove/force
 
 # Add or remove newline between 'template<>' and whatever follows.
 nl_template_class                        = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'class' and '{'
-nl_class_brace                           = ignore   # ignore/add/remove/force
+nl_class_brace                           = remove   # ignore/add/remove/force
 
 # Add or remove newline after each ',' in the constructor member initialization
 nl_class_init_args                       = ignore   # ignore/add/remove/force
@@ -946,16 +946,16 @@ nl_func_type_name_class                  = ignore   # ignore/add/remove/force
 
 # Add or remove newline between function scope and name in a definition
 # Controls the newline after '::' in 'void A::f() { }'
-nl_func_scope_name                       = ignore   # ignore/add/remove/force
+nl_func_scope_name                       = remove   # ignore/add/remove/force
 
 # Add or remove newline between return type and function name in a prototype
 nl_func_proto_type_name                  = ignore   # ignore/add/remove/force
 
 # Add or remove newline between a function name and the opening '('
-nl_func_paren                            = ignore   # ignore/add/remove/force
+nl_func_paren                            = remove   # ignore/add/remove/force
 
 # Add or remove newline between a function name and the opening '(' in the definition
-nl_func_def_paren                        = ignore   # ignore/add/remove/force
+nl_func_def_paren                        = remove   # ignore/add/remove/force
 
 # Add or remove newline after '(' in a function declaration
 nl_func_decl_start                       = ignore   # ignore/add/remove/force
@@ -994,7 +994,7 @@ nl_func_decl_empty                       = ignore   # ignore/add/remove/force
 nl_func_def_empty                        = ignore   # ignore/add/remove/force
 
 # Add or remove newline between function signature and '{'
-nl_fdef_brace                            = ignore   # ignore/add/remove/force
+nl_fdef_brace                            = remove   # ignore/add/remove/force
 
 # Whether to put a newline after 'return' statement
 nl_after_return                          = false    # false/true
@@ -1027,7 +1027,7 @@ nl_after_brace_close                     = false    # false/true
 
 # Whether to put a newline after a virtual brace close.
 # Would add a newline before return in: 'if (foo) a++; return;'
-nl_after_vbrace_close                    = false    # false/true
+nl_after_vbrace_close                    = true     # false/true
 
 # Whether to alter newlines in '#define' macros
 nl_define_macro                          = false    # false/true
@@ -1091,7 +1091,7 @@ nl_create_while_one_liner                = false    # false/true
 #
 # Positioning options
 #
-
+ 
 # The position of arithmetic operators in wrapped expressions
 pos_arith                                = ignore   # ignore/lead/lead_break/lead_force/trail/trail_break/trail_force
 
@@ -1115,14 +1115,14 @@ pos_comma                                = ignore   # ignore/lead/lead_break/lea
 pos_class_comma                          = ignore   # ignore/lead/lead_break/lead_force/trail/trail_break/trail_force
 
 # The position of colons between constructor and member initialization
-pos_class_colon                          = ignore   # ignore/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_class_colon                          = lead_force  # ignore/lead/lead_break/lead_force/trail/trail_break/trail_force
 
 #
 # Line Splitting options
 #
 
 # Try to limit code width to N number of columns
-code_width                               = 0        # number
+code_width                               = 80       # number
 
 # Whether to fully split long 'for' statements at semi-colons
 ls_for_split_full                        = false    # false/true
@@ -1135,7 +1135,7 @@ ls_func_split_full                       = false    # false/true
 #
 
 # The maximum consecutive newlines
-nl_max                                   = 0        # number
+nl_max                                   = 3        # number
 
 # The number of newlines after a function prototype, if followed by another function prototype
 nl_after_func_proto                      = 0        # number
@@ -1176,11 +1176,11 @@ nl_after_class                           = 0        # number
 # The number of newlines before a 'private:', 'public:', 'protected:', 'signals:', or 'slots:' label.
 # Will not change the newline count if after a brace open.
 # 0 = No change.
-nl_before_access_spec                    = 0        # number
+nl_before_access_spec                    = 2        # number
 
 # The number of newlines after a 'private:', 'public:', 'protected:', 'signals:', or 'slots:' label.
 # 0 = No change.
-nl_after_access_spec                     = 0        # number
+nl_after_access_spec                     = 1        # number
 
 # The number of newlines between a function def and the function comment.
 # 0 = No change.
@@ -1212,16 +1212,16 @@ eat_blanks_before_close_brace            = false    # false/true
 #
 
 # Add or remove braces on single-line 'do' statement
-mod_full_brace_do                        = ignore   # ignore/add/remove/force
+mod_full_brace_do                        = force    # ignore/add/remove/force
 
 # Add or remove braces on single-line 'for' statement
-mod_full_brace_for                       = ignore   # ignore/add/remove/force
+mod_full_brace_for                       = force    # ignore/add/remove/force
 
 # Add or remove braces on single-line function definitions. (Pawn)
-mod_full_brace_function                  = ignore   # ignore/add/remove/force
+mod_full_brace_function                  = force    # ignore/add/remove/force
 
 # Add or remove braces on single-line 'if' statement. Will not remove the braces if they contain an 'else'.
-mod_full_brace_if                        = ignore   # ignore/add/remove/force
+mod_full_brace_if                        = force    # ignore/add/remove/force
 
 # Make all if/elseif/else statements in a chain be braced or not. Overrides mod_full_brace_if.
 # If any must be braced, they are all braced.  If all can be unbraced, then the braces are removed.
@@ -1231,22 +1231,22 @@ mod_full_brace_if_chain                  = false    # false/true
 mod_full_brace_nl                        = 0        # number
 
 # Add or remove braces on single-line 'while' statement
-mod_full_brace_while                     = ignore   # ignore/add/remove/force
+mod_full_brace_while                     = force    # ignore/add/remove/force
 
 # Add or remove braces on single-line 'using ()' statement
-mod_full_brace_using                     = ignore   # ignore/add/remove/force
+mod_full_brace_using                     = force    # ignore/add/remove/force
 
 # Add or remove unnecessary paren on 'return' statement
-mod_paren_on_return                      = ignore   # ignore/add/remove/force
+mod_paren_on_return                      = remove   # ignore/add/remove/force
 
 # Whether to change optional semicolons to real semicolons
-mod_pawn_semicolon                       = false    # false/true
+mod_pawn_semicolon                       = true     # false/true
 
 # Add parens on 'while' and 'if' statement around bools
-mod_full_paren_if_bool                   = false    # false/true
+mod_full_paren_if_bool                   = true     # false/true
 
 # Whether to remove superfluous semicolons
-mod_remove_extra_semicolon               = false    # false/true
+mod_remove_extra_semicolon               = true     # false/true
 
 # If a function body exceeds the specified number of newlines and doesn't have a comment after
 # the close brace, a comment will be added.
@@ -1282,7 +1282,7 @@ mod_move_case_break                      = false    # false/true
 mod_case_brace                           = ignore   # ignore/add/remove/force
 
 # If TRUE, it will remove a void 'return;' that appears as the last statement in a function.
-mod_remove_empty_return                  = false    # false/true
+mod_remove_empty_return                  = true     # false/true
 
 #
 # Comment modifications
@@ -1366,13 +1366,13 @@ cmt_insert_before_preproc                = false    # false/true
 #
 
 # Control indent of preprocessors inside #if blocks at brace level 0
-pp_indent                                = ignore   # ignore/add/remove/force
+pp_indent                                = force    # ignore/add/remove/force
 
 # Whether to indent #if/#else/#endif at the brace level (true) or from column 1 (false)
 pp_indent_at_level                       = false    # false/true
 
 # If pp_indent_at_level=false, specifies the number of columns to indent per level. Default=1.
-pp_indent_count                          = 1        # number
+pp_indent_count                          = 2        # number
 
 # Add or remove space after # based on pp_level of #if blocks
 pp_space                                 = ignore   # ignore/add/remove/force


### PR DESCRIPTION
I have updated the uncrustify configuration with the code style from the Google document (http://google-styleguide.googlecode.com/svn/trunk/cppguide.xml).

@ament/owners Please consider trying it with some C++ code and if necessary commit patches to / provide pull request for this branch. You can either run `ament_uncrustify` to see the actual diff or use the option `--reformat` to update the files (which are hopefully under version control) in place.
