### PR TITLE
allow linting based on test dependencies only

### DIFF
--- a/ament_clang_format/ament_clang_format-extras.cmake
+++ b/ament_clang_format/ament_clang_format-extras.cmake
@@ -6,3 +6,6 @@ find_package(ament_cmake_test REQUIRED)
 set(ament_clang_format_BIN "${ament_clang_format_DIR}/../../../bin/ament_clang_format")
 
 include("${ament_clang_format_DIR}/ament_clang_format.cmake")
+
+ament_register_extension("ament_lint_auto" "ament_clang_format"
+  "ament_clang_format_lint_hook.cmake")

--- a/ament_clang_format/cmake/ament_clang_format_lint_hook.cmake
+++ b/ament_clang_format/cmake/ament_clang_format_lint_hook.cmake
@@ -1,0 +1,14 @@
+file(GLOB_RECURSE _source_files FOLLOW_SYMLINKS
+  "*.c"
+  "*.cc"
+  "*.cpp"
+  "*.cxx"
+  "*.h"
+  "*.hh"
+  "*.hpp"
+  "*.hxx"
+)
+if(_source_files)
+  message(" - Added test 'clang_format' to check C / C++ code style")
+  ament_clang_format(clang_format)
+endif()

--- a/ament_copyright/ament_copyright-extras.cmake
+++ b/ament_copyright/ament_copyright-extras.cmake
@@ -5,3 +5,6 @@ find_package(ament_cmake_test REQUIRED)
 set(ament_copyright_BIN "${ament_copyright_DIR}/../../../bin/ament_copyright")
 
 include("${ament_copyright_DIR}/ament_copyright.cmake")
+
+ament_register_extension("ament_lint_auto" "ament_copyright"
+  "ament_copyright_lint_hook.cmake")

--- a/ament_copyright/cmake/ament_copyright_lint_hook.cmake
+++ b/ament_copyright/cmake/ament_copyright_lint_hook.cmake
@@ -1,0 +1,18 @@
+file(GLOB_RECURSE _source_files FOLLOW_SYMLINKS
+  "*.cmake"
+
+  "*.c"
+  "*.cc"
+  "*.cpp"
+  "*.cxx"
+  "*.h"
+  "*.hh"
+  "*.hpp"
+  "*.hxx"
+
+  "*.py"
+)
+if(_source_files)
+  message(" - Added test 'copyright' to check for copyright in CMake / C / C++ / Python code")
+  ament_copyright(copyright)
+endif()

--- a/ament_cppcheck/ament_cppcheck-extras.cmake
+++ b/ament_cppcheck/ament_cppcheck-extras.cmake
@@ -6,3 +6,6 @@ find_package(ament_cmake_test REQUIRED)
 set(ament_cppcheck_BIN "${ament_cppcheck_DIR}/../../../bin/ament_cppcheck")
 
 include("${ament_cppcheck_DIR}/ament_cppcheck.cmake")
+
+ament_register_extension("ament_lint_auto" "ament_cppcheck"
+  "ament_cppcheck_lint_hook.cmake")

--- a/ament_cppcheck/cmake/ament_cppcheck_lint_hook.cmake
+++ b/ament_cppcheck/cmake/ament_cppcheck_lint_hook.cmake
@@ -1,0 +1,14 @@
+file(GLOB_RECURSE _source_files FOLLOW_SYMLINKS
+  "*.c"
+  "*.cc"
+  "*.cpp"
+  "*.cxx"
+  "*.h"
+  "*.hh"
+  "*.hpp"
+  "*.hxx"
+)
+if(_source_files)
+  message(" - Added test 'cppcheck' to perform static code analysis on C / C++ code")
+  ament_cppcheck(cppcheck)
+endif()

--- a/ament_cpplint/ament_cpplint-extras.cmake
+++ b/ament_cpplint/ament_cpplint-extras.cmake
@@ -5,3 +5,6 @@ find_package(ament_cmake_test REQUIRED)
 set(ament_cpplint_BIN "${ament_cpplint_DIR}/../../../bin/ament_cpplint")
 
 include("${ament_cpplint_DIR}/ament_cpplint.cmake")
+
+ament_register_extension("ament_lint_auto" "ament_cpplint"
+  "ament_cpplint_lint_hook.cmake")

--- a/ament_cpplint/cmake/ament_cpplint_lint_hook.cmake
+++ b/ament_cpplint/cmake/ament_cpplint_lint_hook.cmake
@@ -1,0 +1,14 @@
+file(GLOB_RECURSE _source_files FOLLOW_SYMLINKS
+  "*.c"
+  "*.cc"
+  "*.cpp"
+  "*.cxx"
+  "*.h"
+  "*.hh"
+  "*.hpp"
+  "*.hxx"
+)
+if(_source_files)
+  message(" - Added test 'cpplint' to check C / C++ code against the Google style")
+  ament_cpplint(cpplint)
+endif()

--- a/ament_lint_auto/CMakeLists.txt
+++ b/ament_lint_auto/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 2.8.3)
+
+project(ament_lint_auto NONE)
+
+find_package(ament_cmake_core REQUIRED)
+
+ament_package(
+  CONFIG_EXTRAS "ament_lint_auto-extras.cmake"
+)
+
+install(
+  DIRECTORY cmake
+  DESTINATION share/${PROJECT_NAME}
+)

--- a/ament_lint_auto/ament_lint_auto-extras.cmake
+++ b/ament_lint_auto/ament_lint_auto-extras.cmake
@@ -1,0 +1,10 @@
+# copied from ament_lint_auto/ament_lint_auto-extras.cmake
+
+find_package(ament_cmake_core REQUIRED)
+find_package(ament_cmake_test REQUIRED)
+
+include(
+  "${ament_lint_auto_DIR}/ament_lint_auto_find_test_dependencies.cmake")
+
+ament_register_extension("ament_package" "ament_lint_auto"
+  "ament_lint_auto_package_hook.cmake")

--- a/ament_lint_auto/cmake/ament_lint_auto_find_test_dependencies.cmake
+++ b/ament_lint_auto/cmake/ament_lint_auto_find_test_dependencies.cmake
@@ -1,0 +1,26 @@
+#
+# Invoke find_package() for all test dependencies.
+#
+# All found package names are appended to the
+# ``${PROJECT_NAME}_FOUND_TEST_DEPENDS`` variables.
+#
+# @public
+#
+macro(ament_lint_auto_find_test_dependencies)
+  if(ARGN)
+    message(FATAL_ERROR "ament_lint_auto_find_test_dependencies() called with "
+      "unused arguments: ${ARGN}")
+  endif()
+
+  if(NOT _AMENT_PACKAGE_NAME)
+    ament_package_xml()
+  endif()
+
+  # try to find_package() all test dependencies
+  foreach(_dep ${${PROJECT_NAME}_TEST_DEPENDS})
+    find_package(${_dep} QUIET)
+    if(${_dep}_FOUND)
+      list(APPEND ${PROJECT_NAME}_FOUND_TEST_DEPENDS ${_dep})
+    endif()
+  endforeach()
+endmacro()

--- a/ament_lint_auto/cmake/ament_lint_auto_package_hook.cmake
+++ b/ament_lint_auto/cmake/ament_lint_auto_package_hook.cmake
@@ -1,0 +1,1 @@
+ament_execute_extensions(ament_lint_auto)

--- a/ament_lint_auto/package.xml
+++ b/ament_lint_auto/package.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>ament_lint_auto</name>
+  <version>0.0.0</version>
+  <description>The auto-magic functions for ease to use of the ament linters in CMake.</description>
+  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_core</buildtool_depend>
+  <buildtool_depend>ament_cmake_test</buildtool_depend>
+
+  <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
+  <buildtool_export_depend>ament_cmake_test</buildtool_export_depend>
+</package>

--- a/ament_lint_cmake/ament_lint_cmake-extras.cmake
+++ b/ament_lint_cmake/ament_lint_cmake-extras.cmake
@@ -6,3 +6,6 @@ find_package(ament_cmake_test REQUIRED)
 set(ament_lint_cmake_BIN "${ament_lint_cmake_DIR}/../../../bin/ament_lint_cmake")
 
 include("${ament_lint_cmake_DIR}/ament_lint_cmake.cmake")
+
+ament_register_extension("ament_lint_auto" "ament_lint_cmake"
+  "ament_lint_cmake_lint_hook.cmake")

--- a/ament_lint_cmake/cmake/ament_lint_cmake_lint_hook.cmake
+++ b/ament_lint_cmake/cmake/ament_lint_cmake_lint_hook.cmake
@@ -1,0 +1,8 @@
+file(GLOB_RECURSE _cmake_files FOLLOW_SYMLINKS
+  "CMakeLists.txt"
+  "*.cmake"
+)
+if(_cmake_files)
+  message(" - Added test 'lint_cmake' to check CMake code style")
+  ament_lint_cmake(lint_cmake)
+endif()

--- a/ament_lint_common/CMakeLists.txt
+++ b/ament_lint_common/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 2.8.3)
+
+project(ament_lint_common NONE)
+
+find_package(ament_cmake_core REQUIRED)
+find_package(ament_cmake_export_dependencies REQUIRED)
+
+ament_package_xml()
+ament_export_dependencies(${${PROJECT_NAME}_EXEC_DEPENDS})
+ament_package()

--- a/ament_lint_common/package.xml
+++ b/ament_lint_common/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>ament_lint_common</name>
+  <version>0.0.0</version>
+  <description>The list of commonly used linters in the ament buildsytem in CMake.</description>
+  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_core</buildtool_depend>
+  <buildtool_depend>ament_cmake_export_dependencies</buildtool_depend>
+
+  <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
+
+  <exec_depend>ament_clang_format</exec_depend>
+  <exec_depend>ament_copyright</exec_depend>
+  <exec_depend>ament_cppcheck</exec_depend>
+  <exec_depend>ament_cpplint</exec_depend>
+  <exec_depend>ament_lint_cmake</exec_depend>
+  <exec_depend>ament_pep8</exec_depend>
+  <exec_depend>ament_pyflakes</exec_depend>
+  <exec_depend>ament_uncrustify</exec_depend>
+</package>

--- a/ament_pep8/ament_pep8-extras.cmake
+++ b/ament_pep8/ament_pep8-extras.cmake
@@ -6,3 +6,6 @@ find_package(ament_cmake_test REQUIRED)
 set(ament_pep8_BIN "${ament_pep8_DIR}/../../../bin/ament_pep8")
 
 include("${ament_pep8_DIR}/ament_pep8.cmake")
+
+ament_register_extension("ament_lint_auto" "ament_pep8"
+  "ament_pep8_lint_hook.cmake")

--- a/ament_pep8/cmake/ament_pep8_lint_hook.cmake
+++ b/ament_pep8/cmake/ament_pep8_lint_hook.cmake
@@ -1,0 +1,5 @@
+file(GLOB_RECURSE _python_files FOLLOW_SYMLINKS "*.py")
+if(_python_files)
+  message(" - Added test 'pep8' to check Python code against some of the style conventions in PEP 8")
+  ament_pep8(pep8)
+endif()

--- a/ament_pyflakes/ament_pyflakes-extras.cmake
+++ b/ament_pyflakes/ament_pyflakes-extras.cmake
@@ -5,3 +5,6 @@ find_package(ament_cmake_test REQUIRED)
 set(ament_pyflakes_BIN "${ament_pyflakes_DIR}/../../../bin/ament_pyflakes")
 
 include("${ament_pyflakes_DIR}/ament_pyflakes.cmake")
+
+ament_register_extension("ament_lint_auto" "ament_pyflakes"
+  "ament_pyflakes_lint_hook.cmake")

--- a/ament_pyflakes/cmake/ament_pyflakes_lint_hook.cmake
+++ b/ament_pyflakes/cmake/ament_pyflakes_lint_hook.cmake
@@ -1,0 +1,5 @@
+file(GLOB_RECURSE _python_files FOLLOW_SYMLINKS "*.py")
+if(_python_files)
+  message(" - Added test 'pyflakes' to perform static code analysis on Python code")
+  ament_pyflakes(pyflakes)
+endif()

--- a/ament_uncrustify/ament_uncrustify-extras.cmake
+++ b/ament_uncrustify/ament_uncrustify-extras.cmake
@@ -7,3 +7,6 @@ set(ament_uncrustify_BIN "${ament_uncrustify_DIR}/../../../bin/ament_uncrustify"
 set(ament_uncrustify_CFG "${ament_uncrustify_DIR}/../ament_code_style.cfg")
 
 include("${ament_uncrustify_DIR}/ament_uncrustify.cmake")
+
+ament_register_extension("ament_lint_auto" "ament_uncrustify"
+  "ament_uncrustify_lint_hook.cmake")

--- a/ament_uncrustify/cmake/ament_uncrustify_lint_hook.cmake
+++ b/ament_uncrustify/cmake/ament_uncrustify_lint_hook.cmake
@@ -1,0 +1,14 @@
+file(GLOB_RECURSE _source_files FOLLOW_SYMLINKS
+  "*.c"
+  "*.cc"
+  "*.cpp"
+  "*.cxx"
+  "*.h"
+  "*.hh"
+  "*.hpp"
+  "*.hxx"
+)
+if(_source_files)
+  message(" - Added test 'uncrustify' to check C / C++ code style")
+  ament_uncrustify(uncrustify)
+endif()


### PR DESCRIPTION
* add `ament_lint_auto`
* add `ament_lint_common`
* update all linter packages to implement extension point of ament_lint_auto

@esteve @tfoote @wjwwood Please review.