### PR TITLE
Some fixes to ament_lint_cmake

### DIFF
--- a/ament_lint_cmake/ament_lint_cmake/__init__.py
+++ b/ament_lint_cmake/ament_lint_cmake/__init__.py
@@ -37,7 +37,7 @@ def get_xunit_content(report, testname, elapsed):
     for (filename, errors) in report:
 
         if errors:
-            # report each cpplint error as a failing testcase
+            # report each lint_cmake error as a failing testcase
             for error in errors:
                 data = {
                     'quoted_location': quoteattr(
@@ -55,7 +55,7 @@ def get_xunit_content(report, testname, elapsed):
 ''' % data
 
         else:
-            # if there are no cpplint errors report a single successful test
+            # if there are no lint_cmake errors report a single successful test
             data = {
                 'quoted_location': quoteattr(filename),
                 'testname': testname,

--- a/ament_lint_cmake/ament_lint_cmake/cmakelint.py
+++ b/ament_lint_cmake/ament_lint_cmake/cmakelint.py
@@ -16,6 +16,7 @@ https://github.com/richq/cmake-lint/blob/7b85fe46b9bd66fe11ecfef20060f976a49d966
 - allow closing parenthesis to be on the same level as the opening one (lines 281-282)
 - ignore lines with exceeding length if they only contain a single string (lines 35, 196-207)
 - improve SetFilters ability to parse new filters (lines 89-92)
+- implement in file pragmas to control filters on a per file basis (lines 389 - 430)
 """
 from __future__ import print_function
 import sys

--- a/ament_lint_cmake/ament_lint_cmake/cmakelint.py
+++ b/ament_lint_cmake/ament_lint_cmake/cmakelint.py
@@ -15,6 +15,7 @@ https://github.com/richq/cmake-lint/blob/7b85fe46b9bd66fe11ecfef20060f976a49d966
 - removed __version__ import
 - allow closing parenthesis to be on the same level as the opening one (lines 281-282)
 - ignore lines with exceeding length if they only contain a single string (lines 35, 196-207)
+- improve SetFilters ability to parse new filters (lines 89-92)
 """
 from __future__ import print_function
 import sys
@@ -86,10 +87,13 @@ class _CMakeLintState(object):
     def SetFilters(self, filters):
         if not filters:
             return
-        if self.filters:
-            self.filters.extend(filters.split(','))
+        assert isinstance(self.filters, list)
+        if isinstance(filters, list):
+            self.filters.extend(filters)
+        elif isinstance(filters, str):
+            self.filters.extend([f.strip() for f in filters.split(',') if f])
         else:
-            self.filters = filters.split(',')
+            raise ValueError('Filters should be a list or a comma separated string')
         for f in self.filters:
             if f.startswith('-') or f.startswith('+'):
                 allowed = False

--- a/ament_lint_cmake/ament_lint_cmake/cmakelint.py
+++ b/ament_lint_cmake/ament_lint_cmake/cmakelint.py
@@ -386,6 +386,16 @@ def IsValidFile(filename):
     return filename.endswith('.cmake') or os.path.basename(filename).lower() == 'cmakelists.txt'
 
 def ProcessFile(filename):
+    # Store and then restore the filters to prevent pragmas in the file from persisting.
+    original_filters = list(_lint_state.filters)
+    try:
+        return _ProcessFile(filename)
+    finally:
+        _lint_state.filters = original_filters
+
+
+def _ProcessFile(filename):
+    linter_pragma_start = '# lint_cmake: '
     lines = ['# Lines start at 1']
     have_cr = False
     if not IsValidFile(filename):
@@ -393,14 +403,23 @@ def ProcessFile(filename):
         return
     global _package_state
     _package_state = _CMakePackageState()
-    CheckFileName(filename, Error)
     for l in open(filename).readlines():
         l = l.rstrip('\n')
         if l.endswith('\r'):
             have_cr = True
             l = l.rstrip('\r')
         lines.append(l)
+        # Check this line to see if it is a lint_cmake pragma
+        if l.startswith(linter_pragma_start):
+            try:
+                _lint_state.SetFilters(l[len(linter_pragma_start):])
+            except:
+                print("Exception occurred while processing '{0}:{1}':"
+                      .format(filename, len(lines)))
+                raise
     lines.append('# Lines end here')
+    # Check file name after reading lines incase of a # lint_cmake: pragma
+    CheckFileName(filename, Error)
     if have_cr and os.linesep != '\r\n':
         Error(filename, 0, 'whitespace/newline', 'Unexpected carriage return found; '
                 'better to use only \\n')

--- a/ament_lint_cmake/bin/ament_lint_cmake
+++ b/ament_lint_cmake/bin/ament_lint_cmake
@@ -30,6 +30,11 @@ def main(argv=sys.argv[1:]):
         default=[os.curdir],
         help="The files or directories to check. For directories files named "
              "'CMakeLists.txt' and ending in '.cmake' will be considered.")
+    parser.add_argument(
+        '--filters',
+        default="",
+        help="Filters for lint_cmake, for a list of filters see: "
+             "https://github.com/richq/cmake-lint/blob/master/README.md#usage")
     # not using a file handle directly
     # in order to prevent leaving an empty file when something fails early
     parser.add_argument(
@@ -51,6 +56,7 @@ def main(argv=sys.argv[1:]):
 
     # invoke cmake lint
     cmakelint._lint_state.config = cmakelint._DEFAULT_CMAKELINTRC
+    cmakelint._lint_state.SetFilters(args.filters)
     for filename in files:
         # hook into error reporting
         errors = []

--- a/ament_lint_cmake/bin/ament_lint_cmake
+++ b/ament_lint_cmake/bin/ament_lint_cmake
@@ -115,8 +115,8 @@ def get_files(paths):
 
                 # select files by name  / extension
                 for filename in sorted(filenames):
-                    if filename.lower() == 'CMakeLists.txt'.lower() or \
-                            filename.endswith('.cmake'):
+                    fname_low = filename.lower()
+                    if fname_low == 'CMakeLists.txt'.lower() or fname_low.endswith('.cmake'):
                         files.append(os.path.join(dirpath, filename))
         if os.path.isfile(path):
             files.append(path)


### PR DESCRIPTION
Two main things:

- added a `--filters` option to `ament_lint_cmake`
- added the ability to set filters for a file using a CMake comment

@dirk-thomas @esteve @tfoote for review.