### PR TITLE
add env var to prevent ament_cppcheck from using -j#

### DIFF
--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -82,7 +82,7 @@ def main(argv=sys.argv[1:]):
            '-rp',
            '--xml',
            '--xml-version=1']
-    if jobs:
+    if jobs and 'AMENT_CPPCHECK_NO_MULTI_THREADED' not in os.environ:
         cmd.extend(['-j', '%d' % jobs])
     cmd.extend(files)
     try:


### PR DESCRIPTION
For some unknown reason, if `-j` is passed to `cppcheck` it immediately exits docker on exit (both when successful and when failing), stopping the CI build prematurely.

I've added a check for an environment variable, `AMENT_CPPCHECK_NO_MULTI_THREADED `, which when set will prevent `ament_cppcheck` from calling `cppcheck` with `-j`, working around the issue until we can figure out why.

I would do something more fully fledged, like passing this setting in from outside using a CMake variable, but I expect that we will replace this workaround with an actual fix or some other heuristic when we learn more.

I will put together a minimal Dockerfile and report this issue to upstream.

@dirk-thomas @esteve @tfoote for review