### PR TITLE
add missing error category in lint_cmake

### DIFF
--- a/ament_lint_cmake/ament_lint_cmake/cmakelint.py
+++ b/ament_lint_cmake/ament_lint_cmake/cmakelint.py
@@ -64,6 +64,7 @@ _ERROR_CATEGORIES = """\
         convention/filename
         linelength
         package/consistency
+        package/stdargs
         readability/logic
         readability/mixedcase
         readability/wonkycase


### PR DESCRIPTION
Connects to ros2/ros2#21.