### PR TITLE
disable multi-line comment formatting since the result is just not good

### DIFF
--- a/ament_uncrustify/ament_uncrustify/configuration/ament_code_style.cfg
+++ b/ament_uncrustify/ament_uncrustify/configuration/ament_code_style.cfg
@@ -1590,7 +1590,7 @@ cmt_convert_tab_to_spaces                 = false    # false/true
 
 # If false, disable all multi-line comment changes, including cmt_width. keyword substitution, and leading chars.
 # Default is true.
-cmt_indent_multi                          = true     # false/true
+cmt_indent_multi                          = false    # false/true
 
 # Whether to group c-comments that look like they are in a block
 cmt_c_group                               = false    # false/true


### PR DESCRIPTION
See ros2/rmw_connext#94 how the comments needed to look before to be compliant with uncrustify.