### PR TITLE
ensure that ament_package() was called before finding ament_lint_auto

### DIFF
--- a/ament_lint_auto/ament_lint_auto-extras.cmake
+++ b/ament_lint_auto/ament_lint_auto-extras.cmake
@@ -14,6 +14,10 @@
 
 # copied from ament_lint_auto/ament_lint_auto-extras.cmake
 
+if(_${PROJECT_NAME}_AMENT_PACKAGE)
+  message(FATAL_ERROR "find_package(ament_lint_auto) must be called before ament_package()")
+endif()
+
 find_package(ament_cmake_core QUIET REQUIRED)
 find_package(ament_cmake_test QUIET REQUIRED)
 


### PR DESCRIPTION
Depends on ros2/rttest#3.

All other packages seem to comply already: http://ci.ros2.org/job/ros2_batch_ci_osx/181/