### PR TITLE
update cpplint configuration

### DIFF
--- a/ament_cpplint/ament_cpplint/cpplint.py
+++ b/ament_cpplint/ament_cpplint/cpplint.py
@@ -28,7 +28,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# https://code.google.com/p/google-styleguide/source/browse/trunk/cpplint/cpplint.py?r=141
+# https://github.com/google/styleguide/blob/554223dc5432f9bd67951cde662f7a023c512dec/cpplint/cpplint.py
 
 """Does google-lint on c++ files.
 

--- a/ament_cpplint/bin/ament_cpplint
+++ b/ament_cpplint/bin/ament_cpplint
@@ -194,13 +194,18 @@ def append_file_to_group(groups, path):
 
     # try to determine root from path
     base_path = os.path.dirname(path)
-    for p in ['include', 'src', 'test']:
-        match = re.search(
-            '^(.+%s%s)%s' %
-            (re.escape(os.sep), re.escape(p), re.escape(os.sep)), path)
-        if match:
-            base_path = match.group(1)
+    subfolder_names = ['include', 'src', 'test']
+    for p in subfolder_names:
+        if base_path.endswith(os.sep + p):
             break
+    else:
+        for p in subfolder_names:
+            match = re.search(
+                '^(.+%s%s)%s' %
+                (re.escape(os.sep), re.escape(p), re.escape(os.sep)), path)
+            if match:
+                base_path = match.group(1)
+                break
 
     # try to find repository root
     repo_root = None

--- a/ament_cpplint/bin/ament_cpplint
+++ b/ament_cpplint/bin/ament_cpplint
@@ -9,10 +9,33 @@ import re
 import sys
 import time
 
+from ament_cpplint import cpplint
 from ament_cpplint import get_xunit_content
 from ament_cpplint.cpplint import _cpplint_state
 from ament_cpplint.cpplint import ParseArguments
 from ament_cpplint.cpplint import ProcessFile
+
+
+# use custom header guard with two underscore between the name parts
+def CustomGetHeaderGuardCPPVariable(filename):
+    from ament_cpplint.cpplint import _root
+    from ament_cpplint.cpplint import FileInfo
+    # Restores original filename in case that cpplint is invoked from Emacs's
+    # flymake.
+    filename = re.sub(r'_flymake\.h$', '.h', filename)
+    filename = re.sub(r'/\.flymake/([^/]*)$', r'/\1', filename)
+    # Replace 'c++' with 'cpp'.
+    filename = filename.replace('C++', 'cpp').replace('c++', 'cpp')
+
+    fileinfo = FileInfo(filename)
+    file_path_from_root = fileinfo.RepositoryName()
+    if _root:
+        file_path_from_root = re.sub('^' + _root + os.sep, '', file_path_from_root)
+    # use double separator
+    file_path_from_root = file_path_from_root.replace(os.sep, os.sep + os.sep)
+    return re.sub(r'[^a-zA-Z0-9]', '_', file_path_from_root).upper() + '_'
+
+cpplint.GetHeaderGuardCPPVariable = CustomGetHeaderGuardCPPVariable
 
 
 def main(argv=sys.argv[1:]):
@@ -22,6 +45,9 @@ def main(argv=sys.argv[1:]):
         description='Check code against the Google style conventions using '
                     'cpplint.',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        '--linelength', metavar='N', type=int, default=100,
+        help='The maximum line length')
     parser.add_argument(
         'paths',
         nargs='*',
@@ -43,6 +69,21 @@ def main(argv=sys.argv[1:]):
     # collect category based counts
     argv.append('--counting=detailed')
     argv.append('--extensions=%s' % ','.join(extensions))
+    filters = [
+        # we do allow C++11
+        '-build/c++11',
+        # we consider passing non-const references to be ok
+        '-runtime/references',
+        # we wrap open curly braces for namespaces, classes and functions
+        '-whitespace/braces',
+        # we don't indent keywords like public, protected and private with one space
+        '-whitespace/indent',
+        # we allow closing parenthesis to be on the next line
+        '-whitespace/parens',
+    ]
+    argv.append('--filter=%s' % ','.join(filters))
+
+    argv.append('--linelength=%d' % args.linelength)
 
     groups = get_file_groups(args.paths, extensions)
     if not groups:
@@ -83,12 +124,13 @@ def main(argv=sys.argv[1:]):
             errors = []
 
             def custom_error(filename, linenum, category, confidence, message):
-                errors.append({
-                    'linenum': linenum,
-                    'category': category,
-                    'confidence': confidence,
-                    'message': message,
-                })
+                if ament_cpplint.cpplint._ShouldPrintError(category, confidence, linenum):
+                    errors.append({
+                        'linenum': linenum,
+                        'category': category,
+                        'confidence': confidence,
+                        'message': message,
+                    })
                 DefaultError(filename, linenum, category, confidence, message)
             ament_cpplint.cpplint.Error = custom_error
 


### PR DESCRIPTION
The patch also implements a custom include guard pattern which follows the Google style guide with only one difference: instead of a single separator between folder names / namespaces and filenames it uses two. This ensures that separate packages have unique include guards.

The following example would otherwise in the same colliding include guards:
* package `foo_bar` has a file `baz.hpp`
* package `foo` has a file `bar_baz.hpp`

ament/ament_index#6 is an example what we need to update to make our code compliant with cpplint.