### PR TITLE
add ament_cpplint as default linter

### DIFF
--- a/ament_lint_common/package.xml
+++ b/ament_lint_common/package.xml
@@ -15,7 +15,7 @@
   <exec_depend>ament_cmake_copyright</exec_depend>
   <exec_depend>ament_cmake_cppcheck</exec_depend>
   <exec_depend>ament_cmake_lint_cmake</exec_depend>
-  <!--<exec_depend>ament_cpplint</exec_depend>-->
+  <exec_depend>ament_cpplint</exec_depend>
   <exec_depend>ament_cmake_pep257</exec_depend>
   <exec_depend>ament_cmake_pep8</exec_depend>
   <exec_depend>ament_cmake_pyflakes</exec_depend>


### PR DESCRIPTION
Connect to ros2/ros2#12

Should only be merged once the existing code conforms to the new linter.