### PR TITLE
enforce single line comments for closing namespaces

### DIFF
--- a/ament_cpplint/ament_cpplint/cpplint.py
+++ b/ament_cpplint/ament_cpplint/cpplint.py
@@ -2164,7 +2164,7 @@ class _NamespaceInfo(_BlockInfo):
     # expected namespace.
     if self.name:
       # Named namespace
-      if not Match((r'};*\s*(//|/\*).*\bnamespace\s+' + re.escape(self.name) +
+      if not Match((r'};*\s*(//).*\bnamespace\s+' + re.escape(self.name) +
                     r'[\*/\.\\\s]*$'),
                    line):
         error(filename, linenum, 'readability/namespace', 5,
@@ -2172,7 +2172,7 @@ class _NamespaceInfo(_BlockInfo):
               self.name)
     else:
       # Anonymous namespace
-      if not Match(r'};*\s*(//|/\*).*\bnamespace[\*/\.\\\s]*$', line):
+      if not Match(r'};*\s*(//).*\bnamespace[\*/\.\\\s]*$', line):
         # If "// namespace anonymous" or "// anonymous namespace (more text)",
         # mention "// anonymous namespace" as an acceptable form
         if Match(r'}.*\b(namespace anonymous|anonymous namespace)\b', line):

--- a/ament_cpplint/bin/ament_cpplint
+++ b/ament_cpplint/bin/ament_cpplint
@@ -211,6 +211,9 @@ def append_file_to_group(groups, path):
     repo_root = None
     p = path
     while p and repo_root is None:
+        # abort if root is reached
+        if os.path.dirname(p) == p:
+            break
         p = os.path.dirname(p)
         for marker in ['.git', '.hg', '.svn']:
             if os.path.exists(os.path.join(p, marker)):


### PR DESCRIPTION
Also fix an infinite loop when running on files not in a vcs working copy.