### PR TITLE
remove result type extension from testsuite name

### DIFF
--- a/ament_clang_format/bin/ament_clang_format
+++ b/ament_clang_format/bin/ament_clang_format
@@ -185,6 +185,9 @@ def main(argv=sys.argv[1:]):
         suffix = '.xml'
         if file_name.endswith(suffix):
             file_name = file_name[0:-len(suffix)]
+            suffix = '.xunit'
+            if file_name.endswith(suffix):
+                file_name = file_name[0:-len(suffix)]
         testname = '%s.%s' % (folder_name, file_name)
 
         xml = get_xunit_content(report, testname, time.time() - start_time)

--- a/ament_copyright/ament_copyright/main.py
+++ b/ament_copyright/ament_copyright/main.py
@@ -205,6 +205,9 @@ def main(argv=sys.argv[1:]):
         suffix = '.xml'
         if file_name.endswith(suffix):
             file_name = file_name[0:-len(suffix)]
+            suffix = '.xunit'
+            if file_name.endswith(suffix):
+                file_name = file_name[0:-len(suffix)]
         testname = '%s.%s' % (folder_name, file_name)
 
         xml = get_xunit_content(report, testname, time.time() - start_time)

--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -135,6 +135,9 @@ def main(argv=sys.argv[1:]):
         suffix = '.xml'
         if file_name.endswith(suffix):
             file_name = file_name[0:-len(suffix)]
+            suffix = '.xunit'
+            if file_name.endswith(suffix):
+                file_name = file_name[0:-len(suffix)]
         testname = '%s.%s' % (folder_name, file_name)
 
         xml = get_xunit_content(report, testname, time.time() - start_time)

--- a/ament_cpplint/ament_cpplint/main.py
+++ b/ament_cpplint/ament_cpplint/main.py
@@ -171,6 +171,9 @@ def main(argv=sys.argv[1:]):
         suffix = '.xml'
         if file_name.endswith(suffix):
             file_name = file_name[0:-len(suffix)]
+            suffix = '.xunit'
+            if file_name.endswith(suffix):
+                file_name = file_name[0:-len(suffix)]
         testname = '%s.%s' % (folder_name, file_name)
 
         xml = get_xunit_content(report, testname, time.time() - start_time)

--- a/ament_lint_cmake/ament_lint_cmake/main.py
+++ b/ament_lint_cmake/ament_lint_cmake/main.py
@@ -106,6 +106,9 @@ def main(argv=sys.argv[1:]):
         suffix = '.xml'
         if file_name.endswith(suffix):
             file_name = file_name[0:-len(suffix)]
+            suffix = '.xunit'
+            if file_name.endswith(suffix):
+                file_name = file_name[0:-len(suffix)]
         testname = '%s.%s' % (folder_name, file_name)
 
         xml = get_xunit_content(report, testname, time.time() - start_time)

--- a/ament_pep257/ament_pep257/main.py
+++ b/ament_pep257/ament_pep257/main.py
@@ -82,6 +82,9 @@ def main(argv=sys.argv[1:]):
         suffix = '.xml'
         if file_name.endswith(suffix):
             file_name = file_name[0:-len(suffix)]
+            suffix = '.xunit'
+            if file_name.endswith(suffix):
+                file_name = file_name[0:-len(suffix)]
         testname = '%s.%s' % (folder_name, file_name)
 
         xml = get_xunit_content(report, testname, time.time() - start_time)

--- a/ament_pep8/ament_pep8/main.py
+++ b/ament_pep8/ament_pep8/main.py
@@ -85,6 +85,9 @@ def main(argv=sys.argv[1:]):
         suffix = '.xml'
         if file_name.endswith(suffix):
             file_name = file_name[0:-len(suffix)]
+            suffix = '.xunit'
+            if file_name.endswith(suffix):
+                file_name = file_name[0:-len(suffix)]
         testname = '%s.%s' % (folder_name, file_name)
 
         xml = get_xunit_content(report, testname)

--- a/ament_pyflakes/ament_pyflakes/main.py
+++ b/ament_pyflakes/ament_pyflakes/main.py
@@ -89,6 +89,9 @@ def main(argv=sys.argv[1:]):
         suffix = '.xml'
         if file_name.endswith(suffix):
             file_name = file_name[0:-len(suffix)]
+            suffix = '.xunit'
+            if file_name.endswith(suffix):
+                file_name = file_name[0:-len(suffix)]
         testname = '%s.%s' % (folder_name, file_name)
 
         xml = get_xunit_content(report, testname, time.time() - start_time)

--- a/ament_uncrustify/ament_uncrustify/main.py
+++ b/ament_uncrustify/ament_uncrustify/main.py
@@ -237,6 +237,9 @@ def main(argv=sys.argv[1:]):
         suffix = '.xml'
         if file_name.endswith(suffix):
             file_name = file_name[0:-len(suffix)]
+            suffix = '.xunit'
+            if file_name.endswith(suffix):
+                file_name = file_name[0:-len(suffix)]
         testname = '%s.%s' % (folder_name, file_name)
 
         xml = get_xunit_content(report, testname, time.time() - start_time)


### PR DESCRIPTION
Since #27 added the result type extension to make Jenkins happy all the testsuite names had the extra extension in their name. This added an unnecessary level to the hierarchy.

Before: http://ci.ros2.org/job/ros2_batch_ci_linux/621/testReport/ament_clang_format.lint_cmake/
After: http://ci.ros2.org/job/ros2_batch_ci_linux/622/testReport/ament_clang_format/lint_cmake/