### PR TITLE
ignore space after a semi colon

### DIFF
--- a/ament_cpplint/ament_cpplint/main.py
+++ b/ament_cpplint/ament_cpplint/main.py
@@ -101,6 +101,8 @@ def main(argv=sys.argv[1:]):
         '-whitespace/indent',
         # we allow closing parenthesis to be on the next line
         '-whitespace/parens',
+        # we allow the developer to decide about whitespace after a semicolon
+        '-whitespace/semicolon',
     ]
     argv.append('--filter=%s' % ','.join(filters))
 

--- a/ament_uncrustify/ament_uncrustify/configuration/ament_code_style.cfg
+++ b/ament_uncrustify/ament_uncrustify/configuration/ament_code_style.cfg
@@ -453,7 +453,7 @@ sp_before_semi_for                        = ignore   # ignore/add/remove/force
 sp_before_semi_for_empty                  = ignore   # ignore/add/remove/force
 
 # Add or remove space after ';', except when followed by a comment. Default=Add
-sp_after_semi                             = add      # ignore/add/remove/force
+sp_after_semi                             = ignore   # ignore/add/remove/force
 
 # Add or remove space after ';' in non-empty 'for' statements. Default=Force
 sp_after_semi_for                         = force    # ignore/add/remove/force


### PR DESCRIPTION
Sometimes it makes sense to not have whitespace after a semicolon, e.g. `if (true) {return foo;}`. Other times it is appropriate, e.g. `#define FOO(arg) bar(); foo(arg); baz();`. Since `uncrustify` cannot know when it is appropriate I propose we tell it to ignore this rule and we can leave this to the developer's discretion. Since it is ignored, existing code should not be affected, but I could go through and find places it really should not have space after it, but I don't think it matters that much.