### PR TITLE
Make braces optional for single-line if, do, while, and for

### DIFF
--- a/ament_uncrustify/ament_uncrustify/configuration/ament_code_style.cfg
+++ b/ament_uncrustify/ament_uncrustify/configuration/ament_code_style.cfg
@@ -1514,16 +1514,16 @@ nl_between_annotation                     = ignore   # ignore/add/remove/force
 #
 
 # Add or remove braces on single-line 'do' statement
-mod_full_brace_do                         = force    # ignore/add/remove/force
+mod_full_brace_do                         = ignore    # ignore/add/remove/force
 
 # Add or remove braces on single-line 'for' statement
-mod_full_brace_for                        = force    # ignore/add/remove/force
+mod_full_brace_for                        = ignore    # ignore/add/remove/force
 
 # Add or remove braces on single-line function definitions. (Pawn)
 mod_full_brace_function                   = force    # ignore/add/remove/force
 
 # Add or remove braces on single-line 'if' statement. Will not remove the braces if they contain an 'else'.
-mod_full_brace_if                         = force    # ignore/add/remove/force
+mod_full_brace_if                         = ignore    # ignore/add/remove/force
 
 # Make all if/elseif/else statements in a chain be braced or not. Overrides mod_full_brace_if.
 # If any must be braced, they are all braced.  If all can be unbraced, then the braces are removed.
@@ -1533,7 +1533,7 @@ mod_full_brace_if_chain                   = false    # false/true
 mod_full_brace_nl                         = 0        # number
 
 # Add or remove braces on single-line 'while' statement
-mod_full_brace_while                      = force    # ignore/add/remove/force
+mod_full_brace_while                      = ignore    # ignore/add/remove/force
 
 # Add or remove braces on single-line 'using ()' statement
 mod_full_brace_using                      = force    # ignore/add/remove/force


### PR DESCRIPTION
Our style guide (https://github.com/ros2/ros2/wiki/Developer-Guide#c-1) starts with the Google style guide and then makes changes. The Google style guide says that braces are optional for [single-line if statements](https://google.github.io/styleguide/cppguide.html#Conditionals) and also for [single-line loops](https://google.github.io/styleguide/cppguide.html#Loops_and_Switch_Statements). Our guide doesn't modify that stance. And I like foregoing the braces when they're not needed.

This PR brings our configuration into agreement with our guide.