### PR TITLE
ignore pep257 error D203 by default

### DIFF
--- a/ament_pep257/ament_pep257/main.py
+++ b/ament_pep257/ament_pep257/main.py
@@ -38,7 +38,7 @@ def main(argv=sys.argv[1:]):
     parser.add_argument(
         '--ignore',
         nargs='*',
-        default=['D100', 'D101', 'D102', 'D103'],
+        default=['D100', 'D101', 'D102', 'D103', 'D203'],
         help='The pep257 categories to ignore')
     parser.add_argument(
         'paths',


### PR DESCRIPTION
I don't know why this one is getting flagged on my machine and CI (maybe our version of pep257 is out-of-date, but I couldn't find a commit where this was changed) because their documentation explicitly says that it is not in the default list:

From http://pep257.readthedocs.org/en/latest/error_codes.html#default-checks:
> All of the above error codes are checked for by default except for D203.

Either way, I think we should explicitly ignore it by default as well.