### PR TITLE
extend linter API to allow overriding the max line length

### DIFF
--- a/ament_cmake_cpplint/cmake/ament_cpplint.cmake
+++ b/ament_cmake_cpplint/cmake/ament_cpplint.cmake
@@ -17,13 +17,18 @@
 #
 # :param TESTNAME: the name of the test, default: "cpplint"
 # :type TESTNAME: string
+# :param MAX_LINE_LENGTH: override the maximum line length,
+#   the default is defined in ament_cpplint
+# :type MAX_LINE_LENGTH: integer
+# :param ROOT: override the --root option of cpplint
+# :type ROOT: string
 # :param ARGN: the files or directories to check
 # :type ARGN: list of strings
 #
 # @public
 #
 function(ament_cpplint)
-  cmake_parse_arguments(ARG "" "TESTNAME" "" ${ARGN})
+  cmake_parse_arguments(ARG "" "MAX_LINE_LENGTH;ROOT;TESTNAME" "" ${ARGN})
   if(NOT ARG_TESTNAME)
     set(ARG_TESTNAME "cpplint")
   endif()
@@ -35,6 +40,12 @@ function(ament_cpplint)
 
   set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.xunit.xml")
   set(cmd "${ament_cpplint_BIN}" "--xunit-file" "${result_file}")
+  if(ARG_MAX_LINE_LENGTH)
+    list(APPEND cmd "--linelength" "${ARG_MAX_LINE_LENGTH}")
+  endif()
+  if(ARG_ROOT)
+    list(APPEND cmd "--root" "${ARG_ROOT}")
+  endif()
   list(APPEND cmd ${ARG_UNPARSED_ARGUMENTS})
 
   file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/ament_cpplint")

--- a/ament_cmake_pep8/cmake/ament_pep8.cmake
+++ b/ament_cmake_pep8/cmake/ament_pep8.cmake
@@ -17,13 +17,16 @@
 #
 # :param TESTNAME: the name of the test, default: "pep8"
 # :type TESTNAME: string
+# :param MAX_LINE_LENGTH: override the maximum line length,
+#   the default is defined in ament_cpplint
+# :type MAX_LINE_LENGTH: integer
 # :param ARGN: the files or directories to check
 # :type ARGN: list of strings
 #
 # @public
 #
 function(ament_pep8)
-  cmake_parse_arguments(ARG "" "TESTNAME" "" ${ARGN})
+  cmake_parse_arguments(ARG "" "MAX_LINE_LENGTH;TESTNAME" "" ${ARGN})
   if(NOT ARG_TESTNAME)
     set(ARG_TESTNAME "pep8")
   endif()
@@ -35,6 +38,9 @@ function(ament_pep8)
 
   set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.xunit.xml")
   set(cmd "${ament_pep8_BIN}" "--xunit-file" "${result_file}")
+  if(ARG_MAX_LINE_LENGTH)
+    list(APPEND cmd "--linelength" "${ARG_MAX_LINE_LENGTH}")
+  endif()
   list(APPEND cmd ${ARG_UNPARSED_ARGUMENTS})
 
   file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/ament_pep8")

--- a/ament_cmake_uncrustify/cmake/ament_uncrustify.cmake
+++ b/ament_cmake_uncrustify/cmake/ament_uncrustify.cmake
@@ -17,13 +17,16 @@
 #
 # :param TESTNAME: the name of the test, default: "uncrustify"
 # :type TESTNAME: string
+# :param MAX_LINE_LENGTH: override the maximum line length,
+#   the default is defined in ament_uncrustify
+# :type MAX_LINE_LENGTH: integer
 # :param ARGN: the files or directories to check
 # :type ARGN: list of strings
 #
 # @public
 #
 function(ament_uncrustify)
-  cmake_parse_arguments(ARG "" "TESTNAME" "" ${ARGN})
+  cmake_parse_arguments(ARG "" "MAX_LINE_LENGTH;TESTNAME" "" ${ARGN})
   if(NOT ARG_TESTNAME)
     set(ARG_TESTNAME "uncrustify")
   endif()
@@ -35,6 +38,9 @@ function(ament_uncrustify)
 
   set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.xunit.xml")
   set(cmd "${ament_uncrustify_BIN}" "--xunit-file" "${result_file}")
+  if(ARG_MAX_LINE_LENGTH)
+    list(APPEND cmd "--linelength" "${ARG_MAX_LINE_LENGTH}")
+  endif()
   list(APPEND cmd ${ARG_UNPARSED_ARGUMENTS})
 
   file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/ament_uncrustify")

--- a/ament_pep8/ament_pep8/main.py
+++ b/ament_pep8/ament_pep8/main.py
@@ -38,6 +38,9 @@ def main(argv=sys.argv[1:]):
         dest='config_file',
         help='The config file')
     parser.add_argument(
+        '--linelength', metavar='N', type=int,
+        help='The maximum line length (default: specified in the config file)')
+    parser.add_argument(
         'paths',
         nargs='*',
         default=[os.curdir],
@@ -60,7 +63,9 @@ def main(argv=sys.argv[1:]):
         print("Could not config file '%s'" % args.config_file, file=sys.stderr)
         return 1
 
-    report = generate_pep8_report(args.config_file, args.paths, args.excludes)
+    report = generate_pep8_report(
+        args.config_file, args.paths, args.excludes,
+        max_line_length=args.linelength)
 
     # print statistics about errors
     if report.total_errors:
@@ -100,14 +105,17 @@ def main(argv=sys.argv[1:]):
     return rc
 
 
-def generate_pep8_report(config_file, paths, excludes):
-    pep8style = CustomStyleGuide(
-        repeat=True,
-        show_source=True,
-        verbose=True,
-        reporter=CustomReport,
-        config_file=config_file,
-    )
+def generate_pep8_report(config_file, paths, excludes, max_line_length=None):
+    kwargs = {
+        'repeat': True,
+        'show_source': True,
+        'verbose': True,
+        'reporter': CustomReport,
+        'config_file': config_file,
+    }
+    if max_line_length is not None:
+        kwargs['max_line_length'] = max_line_length
+    pep8style = CustomStyleGuide(**kwargs)
     if excludes:
         pep8style.options.exclude += excludes
     return pep8style.check_files(paths)

--- a/ament_pep8/ament_pep8/main.py
+++ b/ament_pep8/ament_pep8/main.py
@@ -193,7 +193,7 @@ class CustomReport(pep8.StandardReport):
             'column': offset + 1,
             'error_code': code,
             'error_message': text,
-            'source_line': line.splitlines()[0],
+            'source_line': line.splitlines()[0] if line else '',
         })
         return code
 


### PR DESCRIPTION
Code generators can't always ensure that the generated code stays within a specific maximum line length. So using this that setting can be overridden.