### PR TITLE
fix handling of --root

### DIFF
--- a/ament_cpplint/ament_cpplint/main.py
+++ b/ament_cpplint/ament_cpplint/main.py
@@ -48,7 +48,12 @@ def CustomGetHeaderGuardCPPVariable(filename):
         # use consistent separator on Windows
         if os.sep != '/':
             prefix = prefix.replace(os.sep, '/')
-        file_path_from_root = re.sub('^' + re.escape(prefix), '', file_path_from_root)
+        if file_path_from_root.startswith(prefix):
+            file_path_from_root = file_path_from_root[len(prefix):]
+        else:
+            filename = filename.replace(os.sep, '/')
+            if filename.startswith(prefix):
+                file_path_from_root = filename[len(prefix):]
     # use double separator
     file_path_from_root = file_path_from_root.replace('/', '//')
     return re.sub(r'[^a-zA-Z0-9]', '_', file_path_from_root).upper() + '_'


### PR DESCRIPTION
If the `RepositoryName` does not start with the prefix also try if the full `filename` path does. This is the case when a custom absolute `--root` is being passed.

Fixes e.g. http://ci.ros2.org/job/ci_linux/1272/testReport/junit/test_communication/cpplint_rosidl_generated_cpp/build_header_guard__5____home_rosbuild_ci_scripts_ws_build_test_communication_rosidl_generator_cpp_test_communication_msg_dynamic_array_primitives__struct_hpp_303_/

After: http://ci.ros2.org/job/ci_linux/1279/

Connect to ros2/rosidl#130