### PR TITLE
(dev) enforcing multiline docstring format

### DIFF
--- a/ament_pep257/ament_pep257/main.py
+++ b/ament_pep257/ament_pep257/main.py
@@ -45,7 +45,7 @@ def main(argv=sys.argv[1:]):
     parser.add_argument(
         '--ignore',
         nargs='*',
-        default=['D100', 'D101', 'D102', 'D103', 'D104', 'D105', 'D203'],
+        default=['D100', 'D101', 'D102', 'D103', 'D104', 'D105', 'D203', 'D212'],
         help='The pep257 categories to ignore')
     parser.add_argument(
         'paths',

--- a/ament_pep257/ament_pep257/main.py
+++ b/ament_pep257/ament_pep257/main.py
@@ -45,7 +45,7 @@ def main(argv=sys.argv[1:]):
     parser.add_argument(
         '--ignore',
         nargs='*',
-        default=['D100', 'D101', 'D102', 'D103', 'D104', 'D105', 'D203', 'D212'],
+        default=['D100', 'D101', 'D102', 'D103', 'D104', 'D105', 'D203', 'D212', 'D404'],
         help='The pep257 categories to ignore')
     parser.add_argument(
         'paths',


### PR DESCRIPTION
by ignoring D212 we implicitely enforce D213 as the multistring comment
format