### PR TITLE
Remove xml warning

### DIFF
--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -79,7 +79,7 @@ def main(argv=sys.argv[1:]):
            '-q',
            '-rp',
            '--xml',
-           '--xml-version=1']
+           '--xml-version=2']
     if jobs:
         cmd.extend(['-j', '%d' % jobs])
     cmd.extend(files)

--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -102,8 +102,7 @@ def main(argv=sys.argv[1:]):
     report = {}
     for filename in files:
         report[filename] = []
-    errors = root.find('errors')
-    for error in errors:
+    for error in root.find('errors'):
         location = error.find('location')
         filename = location.get('file')
         data = {

--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -102,13 +102,15 @@ def main(argv=sys.argv[1:]):
     report = {}
     for filename in files:
         report[filename] = []
-    for error in root.findall('error'):
-        filename = error.get('file')
+    errors = root.find('errors')
+    for error in errors:
+        location = error.find('location')
+        filename = location.get('file')
         data = {
-            'line': int(error.get('line')),
+            'line': int(location.get('line')),
             'id': error.get('id'),
             'severity': error.get('severity'),
-            'msg': error.get('msg'),
+            'msg': error.get('verbose'),
         }
         report[filename].append(data)
 


### PR DESCRIPTION
This PR uses xml version 2 for cppcheck output.

Rationale:
cppcheck deprecated usage of version 1 in the last releases, and will completely drop support in v1.81.
We started to see deprecation warnings show on Mac and Windows CIs (`cppcheck: XML format version 1 is deprecated and will be removed in cppcheck 1.81. Use '--xml-version=2'`) e.g. http://ci.ros2.org/view/nightly/job/nightly_osx_debug/373

Tested with a few errors for either same or different kind and the generated xunit file is identical as with version 1.
Errors tested:
```cpp
void f(char *p) {
    if (p+1){}
}

bool using_introspection_c_typesupport(const char * typesupport_identifier)
{
  double * a = reinterpret_cast<double *>(malloc(10 * sizeof(double)));
  (void)a;
  return true;
}

```