### PR TITLE
Make get_error_type_counts work for legacy api too

### DIFF
--- a/ament_flake8/ament_flake8/legacy.py
+++ b/ament_flake8/ament_flake8/legacy.py
@@ -44,6 +44,9 @@ if LooseVersion(flake8.__version__) < '3.0':
             })
             return code
 
+        def get_error_codes(self):
+            return [e['error_code'] for e in self.errors]
+
     class CustomStyleGuide(flake8.engine.NoQAStyleGuide):
 
         def input_file(self, filename, **kwargs):

--- a/ament_flake8/ament_flake8/main.py
+++ b/ament_flake8/ament_flake8/main.py
@@ -89,7 +89,7 @@ def main(argv=sys.argv[1:]):
         print('%d errors' % (report.total_errors))
 
         print('')
-        error_type_counts = report.get_error_type_counts()
+        error_type_counts = get_error_type_counts(report.get_error_codes())
         for k, v in error_type_counts.items():
             print("'%s'-type errors: %d" % (k, v))
 
@@ -228,6 +228,19 @@ def get_xunit_content(report, testname, elapsed):
     return xml
 
 
+def get_error_type_counts(error_codes):
+    # Determine the type of error by the first character in its error code
+    # e.g. 'E261' is type 'E'
+    error_types = sorted(set([e[0] for e in error_codes]))
+
+    # Create dictionary of error code types and their counts
+    error_type_counts = {}
+    for error_type in error_types:
+        error_type_counts[error_type] = len([
+            e for e in error_codes if e.startswith(error_type)])
+    return error_type_counts
+
+
 class CustomReport(object):
 
     def __init__(self):
@@ -242,19 +255,8 @@ class CustomReport(object):
     def add_error(self, error):
         self.errors.append(error)
 
-    def get_error_type_counts(self):
-        error_codes = [e.code for e in self.errors]
-
-        # Determine the type of error by the first character in its error code
-        # e.g. 'E261' is type 'E'
-        error_types = sorted(set([e[0] for e in error_codes]))
-
-        # Create dictionary of error code types and their counts
-        error_type_counts = {}
-        for error_type in error_types:
-            error_type_counts[error_type] = len([
-                e for e in error_codes if e.startswith(error_type)])
-        return error_type_counts
+    def get_error_codes(self):
+        return [e.code for e in self.errors]
 
     def print_statistics(self):
         self.report._application.report_statistics()


### PR DESCRIPTION
fixes https://github.com/ament/ament_lint/pull/63/files/be9e083d74be769a984666b42e9d12e34d968b0a#r106730822

windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2421)](http://ci.ros2.org/job/ci_windows/2421/)
linux [![Build Status](http://ci.ros2.org/job/ci_linux/2326/badge/icon)](http://ci.ros2.org/job/ci_linux/2326/)
osx [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1785)](http://ci.ros2.org/job/ci_osx/1785/)

with flake8 errors (from this https://github.com/ros2/rclpy/commit/90918e8d76d0468ed2a9957db5eb2857f9dad87a):
windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2422)](http://ci.ros2.org/job/ci_windows/2422/)
linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2327)](http://ci.ros2.org/job/ci_linux/2327/)
osx [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1786)](http://ci.ros2.org/job/ci_osx/1786/)