### PR TITLE
Add python3 and setuptools as build dependencies.

### DIFF
--- a/ament_clang_format/package.xml
+++ b/ament_clang_format/package.xml
@@ -11,6 +11,10 @@
 
   <build_depend>python3-setuptools</build_depend>
 
+  <buildtool_depend>python3</buildtool_depend>
+
+  <buildtool_export_depend>python3</buildtool_export_depend>
+
   <exec_depend>clang-format</exec_depend>
 
   <test_depend>ament_copyright</test_depend>

--- a/ament_clang_format/package.xml
+++ b/ament_clang_format/package.xml
@@ -13,8 +13,7 @@
 
   <buildtool_depend>python3</buildtool_depend>
 
-  <buildtool_export_depend>python3</buildtool_export_depend>
-
+  <exec_depend>python3</exec_depend>
   <exec_depend>clang-format</exec_depend>
 
   <test_depend>ament_copyright</test_depend>

--- a/ament_clang_format/package.xml
+++ b/ament_clang_format/package.xml
@@ -9,6 +9,8 @@
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>
 
+  <build_depend>python3-setuptools</build_depend>
+
   <exec_depend>clang-format</exec_depend>
 
   <test_depend>ament_copyright</test_depend>

--- a/ament_clang_format/package.xml
+++ b/ament_clang_format/package.xml
@@ -13,8 +13,8 @@
 
   <buildtool_depend>python3</buildtool_depend>
 
-  <exec_depend>python3</exec_depend>
   <exec_depend>clang-format</exec_depend>
+  <exec_depend>python3</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_pep8</test_depend>

--- a/ament_cmake_cpplint/package.xml
+++ b/ament_cmake_cpplint/package.xml
@@ -9,8 +9,6 @@
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>
 
-  <build_depend>python3-setuptools</build_depend>
-
   <buildtool_depend>ament_cmake_core</buildtool_depend>
   <buildtool_depend>ament_cmake_test</buildtool_depend>
 

--- a/ament_cmake_cpplint/package.xml
+++ b/ament_cmake_cpplint/package.xml
@@ -9,6 +9,8 @@
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>
 
+  <build_depend>python3-setuptools</build_depend>
+
   <buildtool_depend>ament_cmake_core</buildtool_depend>
   <buildtool_depend>ament_cmake_test</buildtool_depend>
 

--- a/ament_copyright/package.xml
+++ b/ament_copyright/package.xml
@@ -14,7 +14,7 @@
 
   <buildtool_depend>python3</buildtool_depend>
 
-  <buildtool_export_depend>python3</buildtool_export_depend>
+  <exec_depend>python3</exec_depend>
 
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_pep8</test_depend>

--- a/ament_copyright/package.xml
+++ b/ament_copyright/package.xml
@@ -10,6 +10,8 @@
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>
 
+  <build_depend>python3-setuptools</build_depend>
+
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_pep8</test_depend>
   <test_depend>ament_pyflakes</test_depend>

--- a/ament_copyright/package.xml
+++ b/ament_copyright/package.xml
@@ -12,6 +12,10 @@
 
   <build_depend>python3-setuptools</build_depend>
 
+  <buildtool_depend>python3</buildtool_depend>
+
+  <buildtool_export_depend>python3</buildtool_export_depend>
+
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_pep8</test_depend>
   <test_depend>ament_pyflakes</test_depend>

--- a/ament_cppcheck/package.xml
+++ b/ament_cppcheck/package.xml
@@ -10,6 +10,8 @@
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>
 
+  <build_depend>python3-setuptools</build_depend>
+
   <exec_depend>cppcheck</exec_depend>
 
   <export>

--- a/ament_cppcheck/package.xml
+++ b/ament_cppcheck/package.xml
@@ -12,6 +12,10 @@
 
   <build_depend>python3-setuptools</build_depend>
 
+  <buildtool_depend>python3</buildtool_depend>
+
+  <buildtool_export_depend>python3</buildtool_export_depend>
+
   <exec_depend>cppcheck</exec_depend>
 
   <export>

--- a/ament_cppcheck/package.xml
+++ b/ament_cppcheck/package.xml
@@ -14,8 +14,7 @@
 
   <buildtool_depend>python3</buildtool_depend>
 
-  <buildtool_export_depend>python3</buildtool_export_depend>
-
+  <exec_depend>python3</exec_depend>
   <exec_depend>cppcheck</exec_depend>
 
   <export>

--- a/ament_cppcheck/package.xml
+++ b/ament_cppcheck/package.xml
@@ -14,8 +14,8 @@
 
   <buildtool_depend>python3</buildtool_depend>
 
-  <exec_depend>python3</exec_depend>
   <exec_depend>cppcheck</exec_depend>
+  <exec_depend>python3</exec_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/ament_cpplint/package.xml
+++ b/ament_cpplint/package.xml
@@ -10,6 +10,8 @@
   <license>Apache License 2.0</license>
   <license>BSD</license>
 
+  <build_depend>python3-setuptools</build_depend>
+
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_pep8</test_depend>
   <test_depend>ament_pep257</test_depend>

--- a/ament_cpplint/package.xml
+++ b/ament_cpplint/package.xml
@@ -14,7 +14,7 @@
 
   <buildtool_depend>python3</buildtool_depend>
 
-  <buildtool_export_depend>python3</buildtool_export_depend>
+  <exec_depend>python3</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_pep8</test_depend>

--- a/ament_cpplint/package.xml
+++ b/ament_cpplint/package.xml
@@ -12,6 +12,10 @@
 
   <build_depend>python3-setuptools</build_depend>
 
+  <buildtool_depend>python3</buildtool_depend>
+
+  <buildtool_export_depend>python3</buildtool_export_depend>
+
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_pep8</test_depend>
   <test_depend>ament_pep257</test_depend>

--- a/ament_flake8/package.xml
+++ b/ament_flake8/package.xml
@@ -9,6 +9,8 @@
   <maintainer email="dhood@osrfoundation.org">D. Hood</maintainer>
   <license>Apache License 2.0</license>
 
+  <build_depend>python3-setuptools</build_depend>
+
   <exec_depend>python3-flake8</exec_depend>
 
   <export>

--- a/ament_flake8/package.xml
+++ b/ament_flake8/package.xml
@@ -13,8 +13,7 @@
 
   <buildtool_depend>python3</buildtool_depend>
 
-  <buildtool_export_depend>python3</buildtool_export_depend>
-
+  <exec_depend>python3</exec_depend>
   <exec_depend>python3-flake8</exec_depend>
 
   <export>

--- a/ament_flake8/package.xml
+++ b/ament_flake8/package.xml
@@ -11,6 +11,10 @@
 
   <build_depend>python3-setuptools</build_depend>
 
+  <buildtool_depend>python3</buildtool_depend>
+
+  <buildtool_export_depend>python3</buildtool_export_depend>
+
   <exec_depend>python3-flake8</exec_depend>
 
   <export>

--- a/ament_lint_cmake/package.xml
+++ b/ament_lint_cmake/package.xml
@@ -14,7 +14,7 @@
 
   <buildtool_depend>python3</buildtool_depend>
 
-  <buildtool_export_depend>python3</buildtool_export_depend>
+  <exec_depend>python3</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/ament_lint_cmake/package.xml
+++ b/ament_lint_cmake/package.xml
@@ -12,6 +12,10 @@
 
   <build_depend>python3-setuptools</build_depend>
 
+  <buildtool_depend>python3</buildtool_depend>
+
+  <buildtool_export_depend>python3</buildtool_export_depend>
+
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>

--- a/ament_lint_cmake/package.xml
+++ b/ament_lint_cmake/package.xml
@@ -10,6 +10,8 @@
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>
 
+  <build_depend>python3-setuptools</build_depend>
+
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>

--- a/ament_pep257/package.xml
+++ b/ament_pep257/package.xml
@@ -13,6 +13,10 @@
 
   <build_depend>python3-setuptools</build_depend>
 
+  <buildtool_depend>python3</buildtool_depend>
+
+  <buildtool_export_depend>python3</buildtool_export_depend>
+
   <exec_depend>pydocstyle</exec_depend>
 
   <test_depend>ament_pep8</test_depend>

--- a/ament_pep257/package.xml
+++ b/ament_pep257/package.xml
@@ -11,6 +11,8 @@
   <license>Apache License 2.0</license>
   <license>MIT</license>
 
+  <build_depend>python3-setuptools</build_depend>
+
   <exec_depend>pydocstyle</exec_depend>
 
   <test_depend>ament_pep8</test_depend>

--- a/ament_pep257/package.xml
+++ b/ament_pep257/package.xml
@@ -15,7 +15,7 @@
 
   <buildtool_depend>python3</buildtool_depend>
 
-  <buildtool_export_depend>python3</buildtool_export_depend>
+  <exec_depend>python3</exec_depend>
 
   <exec_depend>pydocstyle</exec_depend>
 

--- a/ament_pep257/package.xml
+++ b/ament_pep257/package.xml
@@ -15,9 +15,8 @@
 
   <buildtool_depend>python3</buildtool_depend>
 
-  <exec_depend>python3</exec_depend>
-
   <exec_depend>pydocstyle</exec_depend>
+  <exec_depend>python3</exec_depend>
 
   <test_depend>ament_pep8</test_depend>
 

--- a/ament_pep8/package.xml
+++ b/ament_pep8/package.xml
@@ -10,6 +10,8 @@
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>
 
+  <build_depend>python3-setuptools</build_depend>
+
   <exec_depend>python3-pep8</exec_depend>
 
   <export>

--- a/ament_pep8/package.xml
+++ b/ament_pep8/package.xml
@@ -12,6 +12,9 @@
 
   <build_depend>python3-setuptools</build_depend>
 
+  <buildtool_depend>python3</buildtool_depend>
+
+  <exec_depend>python3</exec_depend>
   <exec_depend>python3-pep8</exec_depend>
 
   <export>

--- a/ament_pyflakes/package.xml
+++ b/ament_pyflakes/package.xml
@@ -12,6 +12,10 @@
 
   <build_depend>python3-setuptools</build_depend>
 
+  <buildtool_depend>python3</buildtool_depend>
+
+  <buildtool_export_depend>python3</buildtool_export_depend>
+
   <exec_depend>pyflakes3</exec_depend>
 
   <test_depend>ament_pep8</test_depend>

--- a/ament_pyflakes/package.xml
+++ b/ament_pyflakes/package.xml
@@ -10,6 +10,8 @@
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>
 
+  <build_depend>python3-setuptools</build_depend>
+
   <exec_depend>pyflakes3</exec_depend>
 
   <test_depend>ament_pep8</test_depend>

--- a/ament_pyflakes/package.xml
+++ b/ament_pyflakes/package.xml
@@ -14,7 +14,7 @@
 
   <buildtool_depend>python3</buildtool_depend>
 
-  <buildtool_export_depend>python3</buildtool_export_depend>
+  <exec_depend>python3</exec_depend>
 
   <exec_depend>pyflakes3</exec_depend>
 

--- a/ament_pyflakes/package.xml
+++ b/ament_pyflakes/package.xml
@@ -14,9 +14,8 @@
 
   <buildtool_depend>python3</buildtool_depend>
 
-  <exec_depend>python3</exec_depend>
-
   <exec_depend>pyflakes3</exec_depend>
+  <exec_depend>python3</exec_depend>
 
   <test_depend>ament_pep8</test_depend>
 

--- a/ament_uncrustify/package.xml
+++ b/ament_uncrustify/package.xml
@@ -14,7 +14,7 @@
 
   <buildtool_depend>python3</buildtool_depend>
 
-  <buildtool_export_depend>python3</buildtool_export_depend>
+  <exec_depend>python3</exec_depend>
 
   <exec_depend>uncrustify</exec_depend>
 

--- a/ament_uncrustify/package.xml
+++ b/ament_uncrustify/package.xml
@@ -10,6 +10,8 @@
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>
 
+  <build_depend>python3-setuptools</build_depend>
+
   <exec_depend>uncrustify</exec_depend>
 
   <export>

--- a/ament_uncrustify/package.xml
+++ b/ament_uncrustify/package.xml
@@ -12,6 +12,10 @@
 
   <build_depend>python3-setuptools</build_depend>
 
+  <buildtool_depend>python3</buildtool_depend>
+
+  <buildtool_export_depend>python3</buildtool_export_depend>
+
   <exec_depend>uncrustify</exec_depend>
 
   <export>

--- a/ament_uncrustify/package.xml
+++ b/ament_uncrustify/package.xml
@@ -15,7 +15,6 @@
   <buildtool_depend>python3</buildtool_depend>
 
   <exec_depend>python3</exec_depend>
-
   <exec_depend>uncrustify</exec_depend>
 
   <export>


### PR DESCRIPTION
In order to build python packages with pybuild python3 and setuptools must be present.