### PR TITLE
use OSI website as reference for license

### DIFF
--- a/ament_copyright/ament_copyright/template/bsd2_contributing.txt
+++ b/ament_copyright/ament_copyright/template/bsd2_contributing.txt
@@ -1,3 +1,3 @@
 Any contribution that you make to this repository will
 be under the BSD license 2.0, as dictated by that
-[license](https://en.wikipedia.org/wiki/BSD_licenses#3-clause_license_.28.22BSD_License_2.0.22.2C_.22Revised_BSD_License.22.2C_.22New_BSD_License.22.2C_or_.22Modified_BSD_License.22.29).
+[license](https://opensource.org/licenses/BSD-3-Clause).


### PR DESCRIPTION
Follow up of https://github.com/ament/ament_lint/commit/767257ff141d7957f3c8c7b92106aced95794537#commitcomment-22668604

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2794)](http://ci.ros2.org/job/ci_linux/2794/)
