### PR TITLE
Added more robust comment format support.

### DIFF
--- a/ament_copyright/ament_copyright/parser.py
+++ b/ament_copyright/ament_copyright/parser.py
@@ -175,7 +175,7 @@ def search_copyright_information(content):
     year = '\d{4}'
     year_range = '%s-%s' % (year, year)
     year_or_year_range = '(?:%s|%s)' % (year, year_range)
-    pattern = '^[^\n\r]?\s*Copyright(?:\s+\(c\))?\s+(%s(?:,\s*%s)*),?\s+([^\n\r]+)$' % \
+    pattern = '^[^\n\r]?[\s\*\w]*Copyright(?:\s+\(c\))?\s+(%s(?:,\s*%s)*),?\s+([^\n\r]+)$' % \
         (year_or_year_range, year_or_year_range)
     regex = re.compile(pattern, re.DOTALL | re.MULTILINE)
 
@@ -198,7 +198,8 @@ def scan_past_coding_and_shebang_lines(content):
     while (
         is_comment_line(content, index) and
         (is_coding_line(content, index) or
-         is_shebang_line(content, index))
+         is_shebang_line(content, index) or
+         is_empty_line(content, index))
     ):
         index = get_index_of_next_line(content, index)
     return index
@@ -239,7 +240,7 @@ def is_shebang_line(content, index):
 
 def get_comment_block(content, index):
     # regex for matching the beginning of the first comment
-    pattern = '^(#|//)'
+    pattern = '^(#|//|/\*\*|/\*)'
     regex = re.compile(pattern, re.MULTILINE)
 
     match = regex.search(content, index)
@@ -248,6 +249,8 @@ def get_comment_block(content, index):
     comment_token = match.group(1)
     start_index = match.start(1)
 
+    if comment_token in ['/*', '/**']:
+        comment_token = ' *'
     end_index = start_index
     while True:
         end_index = get_index_of_next_line(content, end_index)

--- a/ament_copyright/ament_copyright/parser.py
+++ b/ament_copyright/ament_copyright/parser.py
@@ -175,7 +175,7 @@ def search_copyright_information(content):
     year = '\d{4}'
     year_range = '%s-%s' % (year, year)
     year_or_year_range = '(?:%s|%s)' % (year, year_range)
-    pattern = '^[^\n\r]?[\s\*\w]*Copyright(?:\s+\(c\))?\s+(%s(?:,\s*%s)*),?\s+([^\n\r]+)$' % \
+    pattern = '^[^\n\r]?[\s\w]*Copyright(?:\s+\(c\))?\s+(%s(?:,\s*%s)*),?\s+([^\n\r]+)$' % \
         (year_or_year_range, year_or_year_range)
     regex = re.compile(pattern, re.DOTALL | re.MULTILINE)
 


### PR DESCRIPTION
I've tested this as-is with the following:

```c
/*
 * slam_gmapping
 * Copyright (c) 2008, Willow Garage, Inc.
 * Copyright (c) 2017, Open Source Robotics Foundation, Inc.
 *
 * THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS CREATIVE
 * COMMONS PUBLIC LICENSE ("CCPL" OR "LICENSE"). THE WORK IS PROTECTED BY
 * COPYRIGHT AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS
 * AUTHORIZED UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
 *
 * BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HERE, YOU ACCEPT AND AGREE TO
 * BE BOUND BY THE TERMS OF THIS LICENSE. THE LICENSOR GRANTS YOU THE RIGHTS
 * CONTAINED HERE IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
 * CONDITIONS.
 *
 */
```

and got

```
src/slam_gmapping.cpp: copyright=Willow Garage, Inc. (2008), Open Source Robotics Foundation, Inc. (2017), license=<unknown>
```

which seems to be correct (since we don't have a BSD template).

I do not know enough to call this resolved, however.


connects to #75

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ament/ament_lint/82)
<!-- Reviewable:end -->
