### PR TITLE
Add new D107 linter error to ignored list

### DIFF
--- a/ament_flake8/ament_flake8/configuration/ament_flake8.ini
+++ b/ament_flake8/ament_flake8/configuration/ament_flake8.ini
@@ -1,5 +1,5 @@
 [flake8]
-ignore = C816,D100,D101,D102,D103,D104,D105,D107,D203,D212,D404
+ignore = C816,D100,D101,D102,D103,D104,D105,D106,D107,D203,D212,D404
 import-order-style = google
 max-line-length = 99
 show-source = true

--- a/ament_flake8/ament_flake8/configuration/ament_flake8.ini
+++ b/ament_flake8/ament_flake8/configuration/ament_flake8.ini
@@ -1,5 +1,5 @@
 [flake8]
-ignore = C816,D100,D101,D102,D103,D104,D105,D203,D212,D404
+ignore = C816,D100,D101,D102,D103,D104,D105,D107,D203,D212,D404
 import-order-style = google
 max-line-length = 99
 show-source = true

--- a/ament_pep257/ament_pep257/main.py
+++ b/ament_pep257/ament_pep257/main.py
@@ -45,7 +45,10 @@ def main(argv=sys.argv[1:]):
     parser.add_argument(
         '--ignore',
         nargs='*',
-        default=['D100', 'D101', 'D102', 'D103', 'D104', 'D105', 'D107', 'D203', 'D212', 'D404'],
+        default=[
+            'D100', 'D101', 'D102', 'D103', 'D104', 'D105', 'D106', 'D107',
+            'D203', 'D212', 'D404',
+        ],
         help='The pep257 categories to ignore')
     parser.add_argument(
         'paths',

--- a/ament_pep257/ament_pep257/main.py
+++ b/ament_pep257/ament_pep257/main.py
@@ -45,7 +45,7 @@ def main(argv=sys.argv[1:]):
     parser.add_argument(
         '--ignore',
         nargs='*',
-        default=['D100', 'D101', 'D102', 'D103', 'D104', 'D105', 'D203', 'D212', 'D404'],
+        default=['D100', 'D101', 'D102', 'D103', 'D104', 'D105', 'D107', 'D203', 'D212', 'D404'],
         help='The pep257 categories to ignore')
     parser.add_argument(
         'paths',


### PR DESCRIPTION
This is a new error code that has been introduced in pydocstyle v2.1.0: https://github.com/PyCQA/pydocstyle/pull/277 (previously the errors were reported as D102).

CI including turtlebot repos that (mostly) only runs linters: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_turtlebot-demo_linux&build=100)](http://ci.ros2.org/job/ci_turtlebot-demo_linux/100/)

http://ci.ros2.org/job/ci_turtlebot-demo_linux/100/testReport/(root)/test_flake8/ compared to http://ci.ros2.org/view/nightly/job/nightly_turtlebot-demo_linux_release/90/testReport/(root)/test_flake8/ in the last nightly