### PR TITLE
Adapt to flake8 v3.5.0 changes

### DIFF
--- a/ament_flake8/ament_flake8/main.py
+++ b/ament_flake8/ament_flake8/main.py
@@ -123,6 +123,10 @@ def main(argv=sys.argv[1:]):
 
 def get_flake8_style_guide(argv):
     application = flake8_app.Application()
+    application.parse_preliminary_options_and_args([])
+    flake8.configure_logging(
+        application.prelim_opts.verbose, application.prelim_opts.output_file)
+    application.make_config_finder()
     application.find_plugins()
     application.register_plugin_options()
     application.parse_configuration_and_cli(argv)

--- a/ament_flake8/ament_flake8/main.py
+++ b/ament_flake8/ament_flake8/main.py
@@ -122,6 +122,11 @@ def main(argv=sys.argv[1:]):
 
 
 def get_flake8_style_guide(argv):
+    # This is a modified version of flake8.legacy.get_style_guide() in which we pass argv through
+    # to parse_configuration_and_cli(), as opposed to a dict of flake8 options.
+    # Since we are using config files and a mix plugins, it is not trivial to determine the
+    # appropriate options to pass into the standard flake8.legacy.get_style_guide();
+    # passing argv gets it to determine the options for us.
     application = flake8_app.Application()
     application.parse_preliminary_options_and_args([])
     flake8.configure_logging(


### PR DESCRIPTION
Fixes ros2/build_cop#63

This flake8 commit added new required steps in `get_style_guide()`: https://gitlab.com/pycqa/flake8/commit/4e58068657ece52e3f1636cb028e42c15b86fec3#bfbbf9e8e795dd8a51b495abc077f8ecce7a4f39_29_30

This package has a fork of that method (explanation added in https://github.com/ament/ament_lint/commit/55dc119d1b10db929e68d21d60e5687e30dead83), so this PR adapts the fork to contain the new steps.

CI still running; opening for visibility:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3380)](http://ci.ros2.org/job/ci_linux/3380/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=629)](http://ci.ros2.org/job/ci_linux-aarch64/629/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2712)](http://ci.ros2.org/job/ci_osx/2712/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3431)](http://ci.ros2.org/job/ci_windows/3431/)