### PR TITLE
Increase cpplint timeout

### DIFF
--- a/ament_cmake_cpplint/cmake/ament_cpplint.cmake
+++ b/ament_cmake_cpplint/cmake/ament_cpplint.cmake
@@ -24,13 +24,15 @@
 # :type MAX_LINE_LENGTH: integer
 # :param ROOT: override the --root option of cpplint
 # :type ROOT: string
+# :param TIMEOUT: the test timeout in seconds, default: 60
+# :type TIMEOUT: integer
 # :param ARGN: the files or directories to check
 # :type ARGN: list of strings
 #
 # @public
 #
 function(ament_cpplint)
-  cmake_parse_arguments(ARG "" "MAX_LINE_LENGTH;ROOT;TESTNAME" "FILTERS" ${ARGN})
+  cmake_parse_arguments(ARG "" "MAX_LINE_LENGTH;ROOT;TESTNAME;TIMEOUT" "FILTERS" ${ARGN})
   if(NOT ARG_TESTNAME)
     set(ARG_TESTNAME "cpplint")
   endif()
@@ -53,6 +55,9 @@ function(ament_cpplint)
     list(APPEND cmd "--root" "${ARG_ROOT}")
   endif()
   list(APPEND cmd ${ARG_UNPARSED_ARGUMENTS})
+  if(NOT ARG_TIMEOUT)
+    set(ARG_TIMEOUT 120)
+  endif()
 
   file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/ament_cpplint")
   ament_add_test(
@@ -61,7 +66,7 @@ function(ament_cpplint)
     OUTPUT_FILE "${CMAKE_BINARY_DIR}/ament_cpplint/${ARG_TESTNAME}.txt"
     RESULT_FILE "${result_file}"
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-    TIMEOUT 120
+    TIMEOUT "${ARG_TIMEOUT}"
   )
   set_tests_properties(
     "${ARG_TESTNAME}"

--- a/ament_cmake_cpplint/cmake/ament_cpplint.cmake
+++ b/ament_cmake_cpplint/cmake/ament_cpplint.cmake
@@ -61,6 +61,7 @@ function(ament_cpplint)
     OUTPUT_FILE "${CMAKE_BINARY_DIR}/ament_cpplint/${ARG_TESTNAME}.txt"
     RESULT_FILE "${result_file}"
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    TIMEOUT 120
   )
   set_tests_properties(
     "${ARG_TESTNAME}"

--- a/ament_cmake_cpplint/cmake/ament_cpplint.cmake
+++ b/ament_cmake_cpplint/cmake/ament_cpplint.cmake
@@ -24,7 +24,7 @@
 # :type MAX_LINE_LENGTH: integer
 # :param ROOT: override the --root option of cpplint
 # :type ROOT: string
-# :param TIMEOUT: the test timeout in seconds, default: 60
+# :param TIMEOUT: the test timeout in seconds, default: 120
 # :type TIMEOUT: integer
 # :param ARGN: the files or directories to check
 # :type ARGN: list of strings


### PR DESCRIPTION
cpplint on arm is hitting the 60-second limit for some packages (http://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_release/254/).

This  exposes the timeout argument and sets it to 120 by default so that we're safe in the future. 

Looking at the time of all linters, this seems to be the only one that needs to be bumped. But I can propagate it to the other linters if we want to have the same set of parameters everywhere.

* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=905)](http://ci.ros2.org/job/ci_linux-aarch64/905/)