### PR TITLE
Avoid use of builtin 'license' as variable name

### DIFF
--- a/ament_copyright/ament_copyright/parser.py
+++ b/ament_copyright/ament_copyright/parser.py
@@ -59,8 +59,8 @@ class FileDescriptor:
         if content is None:
             return
 
-        for name, license in get_licenses().items():
-            template = getattr(license, license_part).replace('\n', ' ').strip()
+        for name, license_ in get_licenses().items():
+            template = getattr(license_, license_part).replace('\n', ' ').strip()
             last_index = -1
             for license_section in template.split('{company}'):
                 # OK, now look for each section of the license in the incoming


### PR DESCRIPTION
Reported now by `flake8-builtins` (https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_debug/396/testReport/junit/ament_copyright.test/test_flake8/test_flake8/)

CI up to `ament_copyright`: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4106)](https://ci.ros2.org/job/ci_linux/4106/)