### PR TITLE
fix flake8 warning

### DIFF
--- a/ament_copyright/ament_copyright/parser.py
+++ b/ament_copyright/ament_copyright/parser.py
@@ -53,7 +53,7 @@ class FileDescriptor:
             self.content = h.read()
 
     def parse(self):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def identify_license(self, content, license_part):
         if content is None:


### PR DESCRIPTION
Connect to ros2/build_cop#120.

New warning as of Pyflakes 2.0.0.