### PR TITLE
add ament_(cmake_)xmllint packages

### DIFF
--- a/ament_cmake_xmllint/CMakeLists.txt
+++ b/ament_cmake_xmllint/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(ament_cmake_xmllint NONE)
+
+find_package(ament_cmake_core REQUIRED)
+find_package(ament_cmake_test REQUIRED)
+
+ament_package(
+  CONFIG_EXTRAS "ament_cmake_xmllint-extras.cmake"
+)
+
+install(
+  DIRECTORY cmake
+  DESTINATION share/${PROJECT_NAME}
+)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_copyright REQUIRED)
+  ament_copyright()
+
+  find_package(ament_cmake_lint_cmake REQUIRED)
+  ament_lint_cmake()
+endif()

--- a/ament_cmake_xmllint/ament_cmake_xmllint-extras.cmake
+++ b/ament_cmake_xmllint/ament_cmake_xmllint-extras.cmake
@@ -1,0 +1,22 @@
+# Copyright 2014-2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# copied from ament_cmake_xmllint/ament_cmake_xmllint-extras.cmake
+
+find_package(ament_cmake_test QUIET REQUIRED)
+
+include("${ament_cmake_xmllint_DIR}/ament_xmllint.cmake")
+
+ament_register_extension("ament_lint_auto" "ament_cmake_xmllint"
+  "ament_cmake_xmllint_lint_hook.cmake")

--- a/ament_cmake_xmllint/cmake/ament_cmake_xmllint_lint_hook.cmake
+++ b/ament_cmake_xmllint/cmake/ament_cmake_xmllint_lint_hook.cmake
@@ -1,0 +1,19 @@
+# Copyright 2015-2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+file(GLOB_RECURSE _source_files FOLLOW_SYMLINKS "*.xml")
+if(_source_files)
+  message(STATUS "Added test 'xmllint' to check XML markup files")
+  ament_xmllint()
+endif()

--- a/ament_cmake_xmllint/cmake/ament_xmllint.cmake
+++ b/ament_cmake_xmllint/cmake/ament_xmllint.cmake
@@ -1,0 +1,69 @@
+# Copyright 2014-2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Add a test to check XML files for validity with xmllint.
+#
+# :param TESTNAME: the name of the test, default: "xmllint"
+# :type TESTNAME: string
+# :param ARGN: the files or directories to check
+# :type ARGN: list of strings
+#
+# @public
+#
+function(ament_xmllint)
+  cmake_parse_arguments(ARG "" "MAX_LINE_LENGTH;TESTNAME" "" ${ARGN})
+  if(NOT ARG_TESTNAME)
+    set(ARG_TESTNAME "xmllint")
+  endif()
+
+  find_program(ament_xmllint_BIN NAMES "ament_xmllint")
+  if(NOT ament_xmllint_BIN)
+    message(FATAL_ERROR "ament_xmllint() could not find program 'ament_xmllint'")
+  endif()
+
+  set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.xunit.xml")
+  set(cmd "${ament_xmllint_BIN}" "--xunit-file" "${result_file}")
+  list(APPEND cmd ${ARG_UNPARSED_ARGUMENTS})
+
+  find_program(xmllint_BIN NAMES "xmllint")
+
+  if(NOT xmllint_BIN)
+    if(${CMAKE_VERSION} VERSION_LESS "3.8.0")
+      message(WARNING "WARNING: 'xmllint' not found, skipping xmllint test creation")
+      return()
+    endif()
+  endif()
+
+  file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/ament_xmllint")
+  ament_add_test(
+    "${ARG_TESTNAME}"
+    COMMAND ${cmd}
+    OUTPUT_FILE "${CMAKE_BINARY_DIR}/ament_xmllint/${ARG_TESTNAME}.txt"
+    RESULT_FILE "${result_file}"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+  )
+  set_tests_properties(
+    "${ARG_TESTNAME}"
+    PROPERTIES
+    LABELS "xmllint;linter"
+  )
+  if(NOT xmllint_BIN)
+    set_tests_properties(
+      "${ARG_TESTNAME}"
+      PROPERTIES
+      DISABLED TRUE
+    )
+  endif()
+endfunction()

--- a/ament_cmake_xmllint/doc/index.rst
+++ b/ament_cmake_xmllint/doc/index.rst
@@ -1,0 +1,41 @@
+ament_xmllint
+=============
+
+Checks XML markup files using `xmllint <http://xmlsoft.org/xmllint.html>`_.
+Files with the following extensions are being considered: ``.xml``.
+
+
+How to run the check from the command line?
+-------------------------------------------
+
+The command line tool is provided by the package `ament_xmllint
+<https://github.com/ament/ament_lint>`_.
+
+
+How to run the check from within a CMake ament package as part of the tests?
+----------------------------------------------------------------------------
+
+``package.xml``:
+
+.. code:: xml
+
+    <buildtool_depend>ament_cmake</buildtool_depend>
+    <test_depend>ament_cmake_xmllint</test_depend>
+
+``CMakeLists.txt``:
+
+.. code:: cmake
+
+    find_package(ament_cmake REQUIRED)
+    if(BUILD_TESTING)
+      find_package(ament_cmake_xmllint REQUIRED)
+      ament_xmllint()
+    endif()
+
+When running multiple linters as part of the CMake tests the documentation of
+the package `ament_lint_auto <https://github.com/ament/ament_lint>`_ might
+contain some useful information.
+
+The documentation of the package `ament_cmake_test
+<https://github.com/ament/ament_cmake>`_ provides more information on testing
+in CMake ament packages.

--- a/ament_cmake_xmllint/package.xml
+++ b/ament_cmake_xmllint/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>ament_cmake_xmllint</name>
+  <version>0.5.2</version>
+  <description>
+    The CMake API for ament_xmllint to check XML file using xmmlint.
+  </description>
+  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_core</buildtool_depend>
+  <buildtool_depend>ament_cmake_test</buildtool_depend>
+
+  <buildtool_export_depend>ament_cmake_test</buildtool_export_depend>
+  <buildtool_export_depend>ament_xmllint</buildtool_export_depend>
+
+  <test_depend>ament_cmake_copyright</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/ament_lint_common/package.xml
+++ b/ament_lint_common/package.xml
@@ -20,6 +20,7 @@
   <exec_depend>ament_cmake_lint_cmake</exec_depend>
   <exec_depend>ament_cmake_pep257</exec_depend>
   <exec_depend>ament_cmake_uncrustify</exec_depend>
+  <exec_depend>ament_cmake_xmllint</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/ament_xmllint/ament_xmllint/main.py
+++ b/ament_xmllint/ament_xmllint/main.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+
+# Copyright 2014-2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import time
+from xml.etree import ElementTree
+from xml.sax import make_parser
+from xml.sax import SAXParseException
+from xml.sax.handler import ContentHandler
+from xml.sax.saxutils import escape
+from xml.sax.saxutils import quoteattr
+
+
+def main(argv=sys.argv[1:]):
+    extensions = ['xml']
+
+    parser = argparse.ArgumentParser(
+        description='Check XML markup using xmllint.',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        'paths',
+        nargs='*',
+        default=[os.curdir],
+        help='The files or directories to check. For directories files ending '
+             'in %s will be considered.' %
+             ', '.join(["'.%s'" % e for e in extensions]))
+    parser.add_argument(
+        '--exclude',
+        nargs='*',
+        default=[],
+        help='Exclude specific file names and directory names from the check')
+    # not using a file handle directly
+    # in order to prevent leaving an empty file when something fails early
+    parser.add_argument(
+        '--xunit-file',
+        help='Generate a xunit compliant XML file')
+    args = parser.parse_args(argv)
+
+    if args.xunit_file:
+        start_time = time.time()
+
+    files = get_files(args.paths, extensions, args.exclude)
+    if not files:
+        print('No files found', file=sys.stderr)
+        return 1
+    files = [os.path.abspath(f) for f in files]
+
+    xmllint_bin = shutil.which('xmllint')
+    if not xmllint_bin:
+        return "Could not find 'xmllint' executable"
+
+    report = []
+
+    # invoke xmllint on all files
+    for filename in files:
+        # parse file to extract desired validation information
+        parser = make_parser()
+        parser.setContentHandler(CustomHandler())
+        try:
+            parser.parse(filename)
+        except SAXParseException:
+            pass
+
+        cmd = [xmllint_bin, '--noout', filename]
+        # choose validation options based on handler information
+        for attributes in parser.getContentHandler().xml_model_attributes:
+            schematypens = attributes.get('schematypens')
+            href = attributes.get('href')
+            if schematypens is None or href is None:
+                continue
+            # check for XML schema
+            if schematypens == 'http://www.w3.org/2001/XMLSchema':
+                cmd += ['--schema', href]
+            # check for RelaxNG
+            elif schematypens == 'http://relaxng.org/ns/structure/1.0':
+                cmd += ['--relaxng', href]
+            # check for Schematron
+            elif schematypens == 'http://purl.oclc.org/dsdl/schematron':
+                cmd += ['--schematron', href]
+
+        try:
+            subprocess.check_output(
+                cmd, cwd=os.path.dirname(filename), stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            errors = e.output.decode()
+        else:
+            errors = None
+
+        filename = os.path.relpath(filename, start=os.getcwd())
+        report.append((filename, errors))
+
+    for (filename, errors) in report:
+        if errors is not None:
+            print("File '%s' is invalid:" % filename, file=sys.stderr)
+            for line in errors.splitlines():
+                print(line, file=sys.stderr)
+            print('', file=sys.stderr)
+        else:
+            print("File '%s' is valid" % filename)
+            print('')
+
+    # output summary
+    error_count = sum(1 if r[1] else 0 for r in report)
+    if not error_count:
+        print('No errors')
+        rc = 0
+    else:
+        print('%d files are invalid' % error_count, file=sys.stderr)
+        rc = 1
+
+    # generate xunit file
+    if args.xunit_file:
+        folder_name = os.path.basename(os.path.dirname(args.xunit_file))
+        file_name = os.path.basename(args.xunit_file)
+        suffix = '.xml'
+        if file_name.endswith(suffix):
+            file_name = file_name[0:-len(suffix)]
+            suffix = '.xunit'
+            if file_name.endswith(suffix):
+                file_name = file_name[0:-len(suffix)]
+        testname = '%s.%s' % (folder_name, file_name)
+
+        xml = get_xunit_content(report, testname, time.time() - start_time)
+        path = os.path.dirname(os.path.abspath(args.xunit_file))
+        if not os.path.exists(path):
+            os.makedirs(path)
+        with open(args.xunit_file, 'w') as f:
+            f.write(xml)
+
+    return rc
+
+
+def get_files(paths, extensions, excludes=[]):
+    files = []
+    for path in paths:
+        if os.path.isdir(path):
+            for dirpath, dirnames, filenames in os.walk(path):
+                if 'AMENT_IGNORE' in filenames:
+                    dirnames[:] = []
+                    continue
+                # ignore folder starting with . or _
+                dirnames[:] = [d for d in dirnames if d[0] not in ['.', '_']]
+                # ignore excluded folders
+                dirnames[:] = [d for d in dirnames if d not in excludes]
+                dirnames.sort()
+
+                # select files by extension
+                for filename in sorted(filenames):
+                    if filename in excludes:
+                        continue
+                    _, ext = os.path.splitext(filename)
+                    if ext not in ['.%s' % e for e in extensions]:
+                        continue
+                    files.append(os.path.join(dirpath, filename))
+        if os.path.isfile(path):
+            files.append(path)
+    return [os.path.normpath(f) for f in files]
+
+
+class CustomHandler(ContentHandler):
+
+    def __init__(self):
+        super().__init__()
+        self.xml_model_attributes = []
+
+    def processingInstruction(self, target, data):
+        if target != 'xml-model':
+            return
+
+        root = ElementTree.fromstring('<data ' + data + '/>')
+        self.xml_model_attributes.append(root.attrib)
+
+
+def get_xunit_content(report, testname, elapsed):
+    test_count = len(report)
+    error_count = len([r for r in report if r[1]])
+    data = {
+        'testname': testname,
+        'test_count': test_count,
+        'error_count': error_count,
+        'time': '%.3f' % round(elapsed, 3),
+    }
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+<testsuite
+  name="%(testname)s"
+  tests="%(test_count)d"
+  failures="%(error_count)d"
+  time="%(time)s"
+>
+""" % data
+
+    for (filename, diff_lines) in report:
+
+        if diff_lines:
+            # report any diff as a failing testcase
+            data = {
+                'quoted_location': quoteattr(filename),
+                'testname': testname,
+                'quoted_message': quoteattr(
+                    'Diff with %d lines' % len(diff_lines)
+                ),
+                'cdata': ''.join(diff_lines),
+            }
+            xml += """  <testcase
+    name=%(quoted_location)s
+    classname="%(testname)s"
+  >
+      <failure message=%(quoted_message)s><![CDATA[%(cdata)s]]></failure>
+  </testcase>
+""" % data
+
+        else:
+            # if there is no diff report a single successful test
+            data = {
+                'quoted_location': quoteattr(filename),
+                'testname': testname,
+            }
+            xml += """  <testcase
+    name=%(quoted_location)s
+    classname="%(testname)s"
+    status="No errors"/>
+""" % data
+
+    # output list of checked files
+    data = {
+        'escaped_files': escape(''.join(['\n* %s' % r[0] for r in report])),
+    }
+    xml += """  <system-out>Checked files:%(escaped_files)s</system-out>
+""" % data
+
+    xml += '</testsuite>\n'
+    return xml
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/ament_xmllint/doc/index.rst
+++ b/ament_xmllint/doc/index.rst
@@ -1,0 +1,20 @@
+ament_xmllint
+=============
+
+Checks XML markup files using `xmllint <http://xmlsoft.org/xmllint.html>`_.
+Files with the following extensions are being considered: ``.xml``.
+
+
+How to run the check from the command line?
+-------------------------------------------
+
+.. code:: sh
+
+    ament_xmllint [<path> ...]
+
+
+How to run the check from within a CMake ament package as part of the tests?
+----------------------------------------------------------------------------
+
+The CMake integration is provided by the package `ament_cmake_xmllint
+<https://github.com/ament/ament_lint>`_.

--- a/ament_xmllint/package.xml
+++ b/ament_xmllint/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>ament_xmllint</name>
+  <version>0.5.2</version>
+  <description>
+    The ability to check XML files like the package manifest using xmllint
+    and generate xUnit test result files.
+  </description>
+  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <license>Apache License 2.0</license>
+
+  <exec_depend>libxml2-utils</exec_depend>
+
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/ament_xmllint/setup.py
+++ b/ament_xmllint/setup.py
@@ -1,0 +1,33 @@
+from setuptools import find_packages
+from setuptools import setup
+
+setup(
+    name='ament_xmllint',
+    version='0.5.2',
+    packages=find_packages(exclude=['test']),
+    install_requires=['setuptools'],
+    author='Dirk Thomas',
+    author_email='dthomas@osrfoundation.org',
+    maintainer='Dirk Thomas',
+    maintainer_email='dthomas@osrfoundation.org',
+    url='https://github.com/ament/ament_lint',
+    download_url='https://github.com/ament/ament_lint/releases',
+    keywords=['ROS'],
+    classifiers=[
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python',
+        'Topic :: Software Development',
+    ],
+    description='Check XML markup using xmllint.',
+    long_description="""\
+The ability to check XML files like the package manifest using xmllint
+and generate xUnit test result files.""",
+    license='Apache License, Version 2.0',
+    tests_require=['pytest'],
+    entry_points={
+        'console_scripts': [
+            'ament_xmllint = ament_xmllint.main:main',
+        ],
+    },
+)

--- a/ament_xmllint/test/test_copyright.py
+++ b/ament_xmllint/test/test_copyright.py
@@ -1,0 +1,20 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_copyright.main import main
+
+
+def test_copyright():
+    rc = main(argv=[])
+    assert rc == 0, 'Found errors'

--- a/ament_xmllint/test/test_flake8.py
+++ b/ament_xmllint/test/test_flake8.py
@@ -1,0 +1,20 @@
+# Copyright 2016 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_flake8.main import main
+
+
+def test_flake8():
+    rc = main(argv=[])
+    assert rc == 0, 'Found code style errors / warnings'

--- a/ament_xmllint/test/test_pep257.py
+++ b/ament_xmllint/test/test_pep257.py
@@ -1,0 +1,20 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_pep257.main import main
+
+
+def test_pep257():
+    rc = main(argv=[])
+    assert rc == 0, 'Found docblock style errors'


### PR DESCRIPTION
https://ci.ros2.org/job/ci_linux/4876/testReport/ as an example of failed linting.

If `xmllint` is not available (as it is the case on the non-Linux Jenkins nodes) the tests are being skipped: https://ci.ros2.org/job/ci_linux/4875/testReport/junit/(root)/projectroot/

With other PRs merged this passes CI: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4882)](https://ci.ros2.org/job/ci_linux/4882/)