### PR TITLE
Bsd clause3 fixup

### DIFF
--- a/ament_copyright/ament_copyright/parser.py
+++ b/ament_copyright/ament_copyright/parser.py
@@ -62,7 +62,7 @@ class FileDescriptor:
         for name, license_ in get_licenses().items():
             template = getattr(license_, license_part).replace('\n', ' ').strip()
             last_index = -1
-            for license_section in template.split('{company}'):
+            for license_section in template.split('{copyright_holder}'):
                 # OK, now look for each section of the license in the incoming
                 # content.
                 index = content.replace('\n', ' ').strip().find(license_section.strip())

--- a/ament_copyright/ament_copyright/template/bsd2_header.txt
+++ b/ament_copyright/ament_copyright/template/bsd2_header.txt
@@ -13,7 +13,7 @@ are met:
    copyright notice, this list of conditions and the following
    disclaimer in the documentation and/or other materials provided
    with the distribution.
- * Neither the name of the {company} nor the names of its
+ * Neither the name of {company} nor the names of its
    contributors may be used to endorse or promote products derived
    from this software without specific prior written permission.
 

--- a/ament_copyright/ament_copyright/template/bsd2_header.txt
+++ b/ament_copyright/ament_copyright/template/bsd2_header.txt
@@ -13,7 +13,7 @@ are met:
    copyright notice, this list of conditions and the following
    disclaimer in the documentation and/or other materials provided
    with the distribution.
- * Neither the name of {company} nor the names of its
+ * Neither the name of {copyright_holder} nor the names of its
    contributors may be used to endorse or promote products derived
    from this software without specific prior written permission.
 


### PR DESCRIPTION
As discussed offline, we need to relax the matching of the 3rd clause of the BSD 2 license to make porting easier.
This PR removes the requirement for the `the` preceding the copyright holder.

The second commit is cosmetic and replace the `{company}` placeholder with `{copyright_holder}` as the copyright holder doesn't have to be a company

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5080)](http://ci.ros2.org/job/ci_linux/5080/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1867)](http://ci.ros2.org/job/ci_linux-aarch64/1867/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4213)](http://ci.ros2.org/job/ci_osx/4213/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5064)](http://ci.ros2.org/job/ci_windows/5064/)