### PR TITLE
Extend copyright checker to allow for doxygen-style copyright

### DIFF
--- a/ament_copyright/ament_copyright/parser.py
+++ b/ament_copyright/ament_copyright/parser.py
@@ -175,7 +175,8 @@ def search_copyright_information(content):
     year = '\d{4}'
     year_range = '%s-%s' % (year, year)
     year_or_year_range = '(?:%s|%s)' % (year, year_range)
-    pattern = '^[^\n\r]?\s*Copyright(?:\s+\(c\))?\s+(%s(?:,\s*%s)*),?\s+([^\n\r]+)$' % \
+    pattern = '^[^\n\r]?\s*(?:\\\copyright\s*)?' \
+              'Copyright(?:\s+\(c\))?\s+(%s(?:,\s*%s)*),?\s+([^\n\r]+)$' % \
         (year_or_year_range, year_or_year_range)
     regex = re.compile(pattern, re.DOTALL | re.MULTILINE)
 
@@ -239,7 +240,8 @@ def is_shebang_line(content, index):
 
 def get_comment_block(content, index):
     # regex for matching the beginning of the first comment
-    pattern = '^(#|//)'
+    # check for doxygen comments (///) before regular comments (//)
+    pattern = '^(#|///|//)'
     regex = re.compile(pattern, re.MULTILINE)
 
     match = regex.search(content, index)


### PR DESCRIPTION
## Description

This MR extends the copyright checker's regex to allow doxygen-style copyright:
- Add an optional, non-matching group for `\copyright` => `(?:\\\copyright\s*)?`
    - `(?:<stuff>)` -> Non-capturing group which means that later on in the code, the indexes for the matching groups won't have to change
    - `\\\copyright` -> `\copyright` with the `\` escaped
    - `\s*` -> Any whitespace (or none) after `\copyright`
    - `(<stuff>)?` -> Optional match
- Allow `\\\` in comment blocks

For example, it allows you to (optionally) use:
```cpp
/// \copyright Copyright 2015 Open Source Robotics Foundation, Inc.
///
/// Licensed under the Apache License, Version 2.0 (the "License");
/// you may not use this file except in compliance with the License.
/// You may obtain a copy of the License at
///
///     http://www.apache.org/licenses/LICENSE-2.0
///
/// Unless required by applicable law or agreed to in writing, software
/// distributed under the License is distributed on an "AS IS" BASIS,
/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
/// See the License for the specific language governing permissions and
/// limitations under the License.
```

### How to test
1. Copy paste the copyright header above into a file (`test_copyright.c`)
```
$ ament_copyright test_copyright.c
No errors, checked 1 files
```
2. Files with the non-doxygen style copyright header should continue to pass the checks
