### PR TITLE
Fix lint warnings from invalid escape sequences

### DIFF
--- a/ament_copyright/ament_copyright/main.py
+++ b/ament_copyright/ament_copyright/main.py
@@ -324,7 +324,7 @@ def add_copyright_year(file_descriptors, new_years, verbose):
 
 def get_years_from_string(content):
     # remove all whitespaces
-    content = re.sub('\s', '', content)
+    content = re.sub(r'\s', '', content)
     # split items by comma
     items = content.split(',')
 

--- a/ament_copyright/ament_copyright/parser.py
+++ b/ament_copyright/ament_copyright/parser.py
@@ -172,11 +172,11 @@ def determine_filetype(path):
 
 def search_copyright_information(content):
     # regex for matching years or year ranges (yyyy-yyyy) separated by colons
-    year = '\d{4}'
+    year = r'\d{4}'
     year_range = '%s-%s' % (year, year)
     year_or_year_range = '(?:%s|%s)' % (year, year_range)
-    pattern = '^[^\n\r]?\s*(?:\\\copyright\s*)?' \
-              'Copyright(?:\s+\(c\))?\s+(%s(?:,\s*%s)*),?\s+([^\n\r]+)$' % \
+    pattern = r'^[^\n\r]?\s*(?:\\copyright\s*)?' \
+              r'Copyright(?:\s+\(c\))?\s+(%s(?:,\s*%s)*),?\s+([^\n\r]+)$' % \
         (year_or_year_range, year_or_year_range)
     regex = re.compile(pattern, re.DOTALL | re.MULTILINE)
 

--- a/ament_pep257/ament_pep257/main.py
+++ b/ament_pep257/ament_pep257/main.py
@@ -113,8 +113,8 @@ def generate_pep257_report(paths, excludes, ignore):
     sys.argv = [
         'main',
         '--ignore=' + ','.join(ignore),
-        '--match', '.*\.py',
-        '--match-dir', '[^\._].*',
+        '--match', r'.*\.py',
+        '--match-dir', r'[^\._].*',
     ]
     sys.argv += paths
     conf.parse()


### PR DESCRIPTION
Use raw strings for regex patterns to avoid warnings.

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5348)](http://ci.ros2.org/job/ci_linux/5348/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2078)](http://ci.ros2.org/job/ci_linux-aarch64/2078/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4441)](http://ci.ros2.org/job/ci_osx/4441/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5311)](http://ci.ros2.org/job/ci_windows/5311/)