### PR TITLE
Change spelling of maintainer name.

### DIFF
--- a/ament_cmake_flake8/package.xml
+++ b/ament_cmake_flake8/package.xml
@@ -7,7 +7,7 @@
     The CMake API for ament_flake8 to check code syntax and style conventions
     with flake8.
   </description>
-  <maintainer email="steven@osrfoundation.org">Steven! Ragnarök</maintainer>
+  <maintainer email="steven@osrfoundation.org">Steven! Ragnarok</maintainer>
   <license>Apache License 2.0</license>
   <author email="dhood@osrfoundation.org">D. Hood</author>
 

--- a/ament_flake8/package.xml
+++ b/ament_flake8/package.xml
@@ -6,7 +6,7 @@
   <description>
     The ability to check code for style and syntax conventions with flake8.
   </description>
-  <maintainer email="steven@osrfoundation.org">Steven! Ragnarök</maintainer>
+  <maintainer email="steven@osrfoundation.org">Steven! Ragnarok</maintainer>
   <license>Apache License 2.0</license>
   <author email="dhood@osrfoundation.org">D. Hood</author>
 

--- a/ament_flake8/setup.py
+++ b/ament_flake8/setup.py
@@ -12,7 +12,7 @@ setup(
     zip_safe=False,
     author='D. Hood',
     author_email='dhood@osrfoundation.org',
-    maintainer='Steven! Ragnarök',
+    maintainer='Steven! Ragnarok',
     maintainer_email='steven@osrfoundation.org',
     url='https://github.com/ament/ament_lint',
     download_url='https://github.com/ament/ament_lint/releases',


### PR DESCRIPTION
This is causing failures in CI at the moment. Until I figure out where the issue lies let's just mispell it to unbreak CI.