### PR TITLE
[ament_uncrustify] Account for zero value in line length cmake arg

### DIFF
--- a/ament_cmake_uncrustify/cmake/ament_uncrustify.cmake
+++ b/ament_cmake_uncrustify/cmake/ament_uncrustify.cmake
@@ -38,7 +38,7 @@ function(ament_uncrustify)
 
   set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.xunit.xml")
   set(cmd "${ament_uncrustify_BIN}" "--xunit-file" "${result_file}")
-  if(ARG_MAX_LINE_LENGTH)
+  if(DEFINED ARG_MAX_LINE_LENGTH)
     list(APPEND cmd "--linelength" "${ARG_MAX_LINE_LENGTH}")
   endif()
   list(APPEND cmd ${ARG_UNPARSED_ARGUMENTS})

--- a/ament_uncrustify/ament_uncrustify/configuration/ament_code_style.cfg
+++ b/ament_uncrustify/ament_uncrustify/configuration/ament_code_style.cfg
@@ -1,4 +1,4 @@
-# Uncrustify-0.67
+# Uncrustify-0.68
 
 #
 # General options
@@ -119,6 +119,9 @@ sp_balance_nested_parens        = false    # false/true
 # Add or remove space between ')' and '{'.
 sp_paren_brace                  = force    # ignore/add/remove/force
 
+# Add or remove space between nested braces, i.e. '{{' vs '{ {'.
+sp_brace_brace                  = ignore   # ignore/add/remove/force
+
 # Add or remove space before pointer star '*'.
 sp_before_ptr_star              = force    # ignore/add/remove/force
 
@@ -165,6 +168,9 @@ sp_before_byref_func            = force    # ignore/add/remove/force
 
 # Add or remove space between type and word. Default=Force.
 sp_after_type                   = force    # ignore/add/remove/force
+
+# Add or remove space between 'decltype(...)' and word.
+sp_after_decltype               = ignore   # ignore/add/remove/force
 
 # Add or remove space before the paren in the D constructs 'template Foo(' and 'class Foo('.
 sp_before_template_paren        = ignore   # ignore/add/remove/force
@@ -283,6 +289,12 @@ sp_paren_comma                  = force    # ignore/add/remove/force
 # Add or remove space before the variadic '...' when preceded by a non-punctuator.
 sp_before_ellipsis              = ignore   # ignore/add/remove/force
 
+# Add or remove space between a type and '...'.
+sp_type_ellipsis                = ignore   # ignore/add/remove/force
+
+# Add or remove space between ')' and '...'.
+sp_paren_ellipsis               = ignore   # ignore/add/remove/force
+
 # Add or remove space after class ':'.
 sp_after_class_colon            = force    # ignore/add/remove/force
 
@@ -318,6 +330,15 @@ sp_cpp_cast_paren               = remove   # ignore/add/remove/force
 
 # Add or remove space between 'sizeof' and '('.
 sp_sizeof_paren                 = remove   # ignore/add/remove/force
+
+# Add or remove space between 'sizeof' and '...'.
+sp_sizeof_ellipsis              = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'sizeof...' and '('.
+sp_sizeof_ellipsis_paren        = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'decltype' and '('.
+sp_decltype_paren               = ignore   # ignore/add/remove/force
 
 # Add or remove space after the tag keyword (Pawn).
 sp_after_tag                    = ignore   # ignore/add/remove/force
@@ -415,6 +436,9 @@ sp_func_class_paren_empty       = remove   # ignore/add/remove/force
 
 # Add or remove space between 'return' and '('.
 sp_return_paren                 = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'return' and '{'.
+sp_return_brace                 = ignore   # ignore/add/remove/force
 
 # Add or remove space between '__attribute__' and '('.
 sp_attribute_paren              = ignore   # ignore/add/remove/force
@@ -697,6 +721,10 @@ indent_columns                  = 2        # unsigned number
 # The continuation indent. If non-zero, this overrides the indent of '(' and '=' continuation indents.
 # For FreeBSD, this is set to 4. Negative value is absolute and not increased for each '(' level.
 indent_continue                 = 2        # number
+
+# The continuation indent, only for class header line(s). If non-zero, this
+# overrides the indent of 'class' continuation indents.
+indent_continue_class_head      = 0        # unsigned number
 
 # Indent empty lines - lines which contain only spaces before newline character
 indent_single_newlines          = false    # false/true
@@ -1023,6 +1051,9 @@ nl_while_leave_one_liners       = true     # false/true
 
 # Don't split one-line OC messages.
 nl_oc_msg_leave_one_liner       = false    # false/true
+
+# (OC) Add or remove newline between method declaration and '{'.
+nl_oc_mdef_brace                = ignore   # ignore/add/remove/force
 
 # Add or remove newline between Objective-C block signature and '{'.
 nl_oc_block_brace               = ignore   # ignore/add/remove/force
@@ -1397,7 +1428,7 @@ nl_brace_struct_var             = ignore   # ignore/add/remove/force
 # Whether to alter newlines in '#define' macros.
 nl_define_macro                 = false    # false/true
 
-# Whether to alter newlines between consecutive paren closes, 
+# Whether to alter newlines between consecutive paren closes,
 # The number of closing paren in a line will depend on respective open paren lines
 nl_squeeze_paren_close          = false    # false/true
 
@@ -1517,6 +1548,13 @@ nl_after_func_class_proto       = 0        # unsigned number
 # The number of newlines after a function class prototype, if not followed by another function class prototype.
 nl_after_func_class_proto_group = 0        # unsigned number
 
+# Whether one-line method definitions inside a class body should be treated
+# as if they were prototypes for the purposes of adding newlines.
+#
+# Requires nl_class_leave_one_liners=true. Overrides nl_before_func_body_def
+# and nl_before_func_class_def for one-liners.
+nl_class_leave_one_liner_groups = false    # true/false
+
 # The number of newlines before a multi-line function def body.
 nl_before_func_body_def         = 0        # unsigned number
 
@@ -1587,6 +1625,15 @@ nl_between_get_set              = 0        # unsigned number
 
 # Add or remove newline between C# property and the '{'.
 nl_property_brace               = ignore   # ignore/add/remove/force
+
+# The number of newlines after '{' of a namespace. This also adds newlines
+# before the matching '}'.
+#
+# 0 = Apply eat_blanks_after_open_brace or eat_blanks_before_close_brace if
+#     applicable, otherwise no change.
+#
+# Overrides eat_blanks_after_open_brace and eat_blanks_before_close_brace.
+nl_inside_namespace             = 0        # unsigned number
 
 # Whether to remove blank lines after '{'.
 eat_blanks_after_open_brace     = false    # false/true
@@ -1707,6 +1754,15 @@ align_func_params_gap           = 0        # unsigned number
 # The function names must already be aligned with each other.
 align_same_func_call_params     = false    # false/true
 
+# The span for aligning function-call parameters for single line functions.
+#  0 = Don't align (default).
+align_same_func_call_params_span = 0       # unsigned number
+
+# The threshold for aligning function-call parameters for single line
+# functions.
+#  0 = No limit (default).
+align_same_func_call_params_thresh = 0     # unsigned number
+
 # The span for aligning variable definitions (0=don't align)
 align_var_def_span              = 0        # unsigned number
 
@@ -1745,6 +1801,13 @@ align_assign_span               = 0        # unsigned number
 
 # The threshold for aligning on '=' in assignments (0=no limit)
 align_assign_thresh             = 0        # unsigned number
+
+# How to apply align_assign_span to function declaration "assignments", i.e.
+# 'virtual void foo() = 0' or '~foo() = {default|delete}'.
+#  0: Align with other assignments (default)
+#  1: Align with each other, ignoring regular assignments
+#  2: Don't align
+align_assign_decl_func          = 0        # unsigned number
 
 # The span for aligning on '=' in enums (0=don't align)
 align_enum_equ_span             = 0        # unsigned number
@@ -1802,6 +1865,9 @@ align_right_cmt_span            = 0        # unsigned number
 
 # If aligning comments, mix with comments after '}' and #endif with less than 3 spaces before the comment.
 align_right_cmt_mix             = false    # false/true
+
+# Whether to only align trailing comments that are at the same brace level.
+align_right_cmt_same_level      = false    # true/false
 
 # If a trailing comment is more than this number of columns away from the text it follows,
 # it will qualify for being aligned. This has to be > 0 to do anything.
@@ -2050,6 +2116,9 @@ mod_case_brace                  = ignore   # ignore/add/remove/force
 
 # If True, it will remove a void 'return;' that appears as the last statement in a function.
 mod_remove_empty_return         = true     # false/true
+
+# Add or remove the comma after the last value of an enumeration.
+mod_enum_last_comma             = ignore   # ignore/add/remove/force
 
 # If True, it will organize the properties (Obj-C).
 mod_sort_oc_properties          = false    # false/true


### PR DESCRIPTION
A zero value will cause uncrustify to ignore line length.

Connects to ros2/rosidl#340
Connects to ament/uncrustify_vendor#3