### PR TITLE
Fix CI Remove make_notifier() call

### DIFF
--- a/ament_flake8/ament_flake8/main.py
+++ b/ament_flake8/ament_flake8/main.py
@@ -136,7 +136,6 @@ def get_flake8_style_guide(argv):
     application.register_plugin_options()
     application.parse_configuration_and_cli(argv)
     application.make_formatter()
-    application.make_notifier()
     application.make_guide()
     application.make_file_checker_manager()
     return StyleGuide(application)


### PR DESCRIPTION
A function called `make_notifier()` was removed upstream in https://gitlab.com/pycqa/flake8/commit/be88d2639694da77d07a9075231a0bea2b8df3f5 .

This caused all flake8 tests to fail in all CI jobs

[nightly_linux-aarch64_debug #712](https://ci.ros2.org/job/nightly_linux-aarch64_debug/712), [nightly_linux-aarch64_extra_rmw_release #244](https://ci.ros2.org/job/nightly_linux-aarch64_extra_rmw_release/244), [nightly_linux-aarch64_release #672](https://ci.ros2.org/job/nightly_linux-aarch64_release/672), [nightly_linux_debug #1087](https://ci.ros2.org/job/nightly_linux_debug/1087), [nightly_linux_extra_rmw_release #240](https://ci.ros2.org/job/nightly_linux_extra_rmw_release/240), [nightly_linux_release #1068](https://ci.ros2.org/job/nightly_linux_release/1068), [nightly_osx_debug #1142](https://ci.ros2.org/job/nightly_osx_debug/1142), [nightly_osx_extra_rmw_release #278](https://ci.ros2.org/job/nightly_osx_extra_rmw_release/278), [nightly_osx_release #1150](https://ci.ros2.org/job/nightly_osx_release/1150), [nightly_win_deb #1142](https://ci.ros2.org/job/nightly_win_deb/1142), [nightly_win_extra_rmw_rel #247](https://ci.ros2.org/job/nightly_win_extra_rmw_rel/247), [nightly_win_rel #1081](https://ci.ros2.org/job/nightly_win_rel/1081), [nightly_xenial_linux-aarch64_release #242](https://ci.ros2.org/job/nightly_xenial_linux-aarch64_release/242), [nightly_xenial_linux_release #233](https://ci.ros2.org/job/nightly_xenial_linux_release/233)

It looks like it was called here to set up an `Application` instance, but we don't use or need the feature that was removed upstream.

CI (Just testing ament_flake8 since it's the first package with this failure)

[![Build Status](https://ci.ros2.org/job/ci_linux/6096/badge/icon)](https://ci.ros2.org/job/ci_linux/6096/)