### PR TITLE
use globally defined varible for cppcheck include dirs

### DIFF
--- a/ament_cmake_cppcheck/cmake/ament_cmake_cppcheck_lint_hook.cmake
+++ b/ament_cmake_cppcheck/cmake/ament_cmake_cppcheck_lint_hook.cmake
@@ -29,6 +29,10 @@ if(_source_files)
 
   # Get include paths for added targets
   set(_all_include_dirs "")
+  if(DEFINED ament_cmake_cppcheck_ADDITIONAL_INCLUDE_DIRS)
+    list(APPEND _all_include_dirs ${ament_cmake_cppcheck_ADDITIONAL_INCLUDE_DIRS})
+  endif()
+
   # BUILDSYSTEM_TARGETS only supported in CMake >= 3.7
   if(NOT CMAKE_VERSION VERSION_LESS "3.7.0")
     get_directory_property(_build_targets DIRECTORY ${CMAKE_SOURCE_DIR} BUILDSYSTEM_TARGETS)
@@ -59,5 +63,6 @@ if(_source_files)
     endforeach()
   endif()
 
+  message(STATUS "Configured cppcheck include dirs: ${_all_include_dirs}")
   ament_cppcheck(INCLUDE_DIRS ${_all_include_dirs})
 endif()

--- a/ament_cmake_cppcheck/cmake/ament_cppcheck.cmake
+++ b/ament_cmake_cppcheck/cmake/ament_cppcheck.cmake
@@ -15,6 +15,10 @@
 #
 # Add a test to perform static code analysis with cppcheck.
 #
+# The include dirs for cppcheck to consider can either be set by the function
+# parameter 'INCLUDE_DIRS` or by a global variable called
+# 'ament_cmake_cppcheck_ADDITIONAL_INCLUDE_DIRS'.
+#
 # :param TESTNAME: the name of the test, default: "cppcheck"
 # :type TESTNAME: string
 # :param LANGUAGE: the language argument for cppcheck, either 'c' or 'c++'


### PR DESCRIPTION
introduces a new variable `AMENT_CMAKE_CPPCHECK_INCLUDE_DIRS` which can be set externally to configure cppcheck's include dirs.

the new variable can then be used externally in projects as such:

```
if(BUILD_TESTING)
  find_package(ament_cmake_gmock REQUIRED)
  find_package(ament_lint_auto REQUIRED)
  find_package(test_msgs REQUIRED)
  find_package(rosbag2_test_common REQUIRED)

  set(AMENT_CMAKE_CPPCHECK_INCLUDE_DIRS ${rclcpp_INCLUDE_DIRS})
  ament_lint_auto_find_test_dependencies()

  [...]
```

connects to the CI warnings found here: https://github.com/ros2/rosbag2/pull/86
