### PR TITLE
fix sorting of keys in same cases

### DIFF
--- a/ament_cpplint/ament_cpplint/main.py
+++ b/ament_cpplint/ament_cpplint/main.py
@@ -226,7 +226,7 @@ def get_file_groups(paths, extensions):
 def append_file_to_group(groups, path):
     path = os.path.abspath(path)
 
-    root = None
+    root = ''
 
     # try to determine root from path
     base_path = os.path.dirname(path)


### PR DESCRIPTION
Follow up of #94.

Depending on the layout the [groups](https://github.com/ament/ament_lint/blob/e08e905350821705353fcfc6bd561eb1a52ff895/ament_cpplint/ament_cpplint/main.py#L267) keys might end up containing the default root `None` as well as other `str` values. As a consequence the [sorted](https://github.com/ament/ament_lint/blob/e08e905350821705353fcfc6bd561eb1a52ff895/ament_cpplint/ament_cpplint/main.py#L134) call fails with:

> TypeError: '<' not supported between instances of 'str' and 'NoneType'