### PR TITLE
fix name of included CMake file for cmake_clang_format

### DIFF
--- a/ament_cmake_clang_format/ament_cmake_clang_format-extras.cmake
+++ b/ament_cmake_clang_format/ament_cmake_clang_format-extras.cmake
@@ -16,7 +16,7 @@
 
 find_package(ament_cmake_test QUIET REQUIRED)
 
-include("${ament_cmake_clang_format_DIR}/ament_cmake_clang_format.cmake")
+include("${ament_cmake_clang_format_DIR}/ament_clang_format.cmake")
 
 ament_register_extension("ament_lint_auto" "ament_cmake_clang_format"
 "ament_cmake_clang_format_lint_hook.cmake")

--- a/ament_cmake_clang_format/cmake/ament_clang_format.cmake
+++ b/ament_cmake_clang_format/cmake/ament_clang_format.cmake
@@ -28,15 +28,13 @@ function(ament_clang_format)
     set(ARG_TESTNAME "clang_format")
   endif()
 
-  if(NOT PYTHON_EXECUTABLE)
-    message(FATAL_ERROR "ament_clang_format() variable 'PYTHON_EXECUTABLE' must not be empty")
-  endif()
+  find_program(ament_clang_format_BIN NAMES "ament_clang_format")
   if(NOT ament_clang_format_BIN)
     message(FATAL_ERROR "ament_clang_format() variable 'ament_clang_format_BIN' must not be empty")
   endif()
 
   set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.xunit.xml")
-  set(cmd "${PYTHON_EXECUTABLE}" "${ament_clang_format_BIN}" "--xunit-file" "${result_file}")
+  set(cmd "${ament_clang_format_BIN}" "--xunit-file" "${result_file}")
   list(APPEND cmd ${ARG_UNPARSED_ARGUMENTS})
 
   file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/ament_clang_format")


### PR DESCRIPTION
Based on https://answers.ros.org/question/317464/ament_cmake_clang_format-fails-to-find-ament_clang_format-package/