### PR TITLE
Add PR template (SQWG trial)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!--
+Thanks for submitting a Pull Request!
+
+Please shortly explain your contribution, and if fixing an issue from the tracker, please add a link to the issue.
+
+Be sure to go over each item in the list below before submitting your pull request.
+-->
+
+### Description
+
+Add your description here
+
+
+### Checklist
+
+- [ ] Did you change how any of these packages work? Added new functionality? Make sure to update the documentation of the package (located in the `doc` sub directory)
+- [ ] If you added a new package: make sure to have included documentation (in the `doc` sub directory)
+- [ ] If needed, please include (updated) tests with your PR
+- [ ] While waiting for someone to review your PR, please consider reviewing [another open pull request](https://github.com/ament/ament_lint/pulls) to support the maintainers of `ament_lint`. Refer to the [ROS code review guide](https://github.com/rosin-project/ros_code_review_guide/blob/master/README.md) for general reviewing guidelines and [Quality Guide: Ensuring code quality](https://index.ros.org/doc/ros2/Contributing/Quality-Guide/) for ROS 2 specific guidelines


### PR DESCRIPTION
Similar to https://github.com/ros-visualization/rviz/pull/1312 and https://github.com/ros-planning/moveit/pull/1027.

I've adapted the text for this repository (and ROS 2).

This is part of the trial started by the members of the software quality working group trying to get more people involved in maintainership and increase community participation in these processes.

Connects to ros2/rcl#394