### PR TITLE
[Crystal] Remove make_notifier() call

### DIFF
--- a/ament_flake8/ament_flake8/main.py
+++ b/ament_flake8/ament_flake8/main.py
@@ -136,7 +136,6 @@ def get_flake8_style_guide(argv):
     application.register_plugin_options()
     application.parse_configuration_and_cli(argv)
     application.make_formatter()
-    application.make_notifier()
     application.make_guide()
     application.make_file_checker_manager()
     return StyleGuide(application)


### PR DESCRIPTION
Backport of #124 for Crystal. This issue doesn't affect users of the Debian packages or those using older versions of flake8 from pip but it does make it much harder for us to run Crystal on ci.ros2.org which uses the latest flake8 from pip which motivates the backport.