### PR TITLE
Allow excluding checkers from ament_lint_auto

### DIFF
--- a/ament_lint_auto/cmake/ament_lint_auto_package_hook.cmake
+++ b/ament_lint_auto/cmake/ament_lint_auto_package_hook.cmake
@@ -12,4 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ament_execute_extensions(ament_lint_auto)
+# Use the AMENT_LINT_AUTO_EXCLUDE variable to exclude linter packages from
+# running using the ament_lint_auto hook.
+# It is still possible, however, to use the linter by calling it explicitly.
+#
+# :variable AMENT_LINT_AUTO_EXCLUDE: List of strings (package names)
+
+ament_execute_extensions(ament_lint_auto EXCLUDE "${AMENT_LINT_AUTO_EXCLUDE}")


### PR DESCRIPTION
This PR implements the enhancement proposed in #132. It consists of two commits:

1. A bug fix to the way `ament_lint_auto_find_test_dependencies` detected unused arguments
2. Adding AMENT_LINT_AUTO_EXCLUDE variable to `ament_execute_extension`

- See https://github.com/ament/ament_cmake/pull/165 also
- Example: ros/class_loader#123

## How to test
- Take a package like `rclcpp` which uses `ament_lint_auto_find_test_dependencies` (https://github.com/ros2/rclcpp/blob/master/rclcpp/CMakeLists.txt#L140) :

1. Introduce a couple of style error in a source file, run `colcon build`, `colcon test --packages-select rclcpp` and see that the `cpplint` and `uncrustify` tests fail

2. Exclude one of the checkers:

```cmake
list(APPEND AMENT_LINT_AUTO_EXCLUDE
  ament_cmake_uncrustify
)
ament_lint_auto_find_test_dependencies()
```

- [ ] Run `colcon build --packages-select rclcpp`, `colcon test --packages-select rclcpp` and see that the uncrustify test does not exist any more

3. Find and add the `ament_cmake_uncrustify` check explicitly, excluding the file with the style errors:

```cmake
list(APPEND AMENT_LINT_AUTO_EXCLUDE
  ament_cmake_uncrustify
)
ament_lint_auto_find_test_dependencies()
find_package(ament_cmake_uncrustify)

set(good_sources "${rclcpp_SRCS}")
list(REMOVE_ITEM good_sources <bad-file>)
ament_uncrustify(${good_sources})
```
- [ ] `uncrustify` should succeed

4. Exclude `ament_cmake_cpplint`
```cmake
list(APPEND AMENT_LINT_AUTO_EXCLUDE
  ament_cmake_uncrustify
  ament_cmake_cpplint
)
ament_lint_auto_find_test_dependencies()
find_package(ament_cmake_uncrustify)

set(good_sources "${rclcpp_SRCS}")
list(REMOVE_ITEM good_sources <bad-file>)
ament_uncrustify(${good_sources})
```

- [ ] `cpplint` test does not exist anymore

5. Add the `cpplint` test (before `ament_lint_auto`), but use the `FILTERS` option to suppress the error message:

```cmake
find_package(ament_cmake_cpplint)
ament_cpplint(FILTERS "-foo")

list(APPEND AMENT_LINT_AUTO_EXCLUDE
  ament_cmake_uncrustify
  ament_cmake_cpplint
)
ament_lint_auto_find_test_dependencies()

find_package(ament_cmake_uncrustify)
set(good_sources "${rclcpp_SRCS}")
list(REMOVE_ITEM good_sources <bad-file>)
ament_uncrustify(${good_sources})
```

- [ ] `cpplint` test succeeds