### PR TITLE
use yaml.safe_load instead of deprecated yaml.load

### DIFF
--- a/ament_clang_format/ament_clang_format/main.py
+++ b/ament_clang_format/ament_clang_format/main.py
@@ -91,7 +91,7 @@ def main(argv=sys.argv[1:]):
     # invoke clang_format
     with open(args.config_file, 'r') as h:
         content = h.read()
-    data = yaml.load(content)
+    data = yaml.safe_load(content)
     style = yaml.dump(data, default_flow_style=True, width=float('inf'))
     cmd = [clang_format_bin,
            '-output-replacements-xml',


### PR DESCRIPTION
Similar to https://github.com/colcon/colcon-metadata/pull/14

Note: there may be a similar fix to apply on the `yaml.dump` side. But I didn't face deprecation warnings so far so focused this change on the load side.