### PR TITLE
Fix unused-arg check in auto find test deps

### DIFF
--- a/ament_lint_auto/cmake/ament_lint_auto_find_test_dependencies.cmake
+++ b/ament_lint_auto/cmake/ament_lint_auto_find_test_dependencies.cmake
@@ -21,9 +21,10 @@
 # @public
 #
 macro(ament_lint_auto_find_test_dependencies)
-  if(ARGN)
+  set(_ARGN "${ARGN}")
+  if(_ARGN)
     message(FATAL_ERROR "ament_lint_auto_find_test_dependencies() called with "
-      "unused arguments: ${ARGN}")
+      "unused arguments: ${_ARGN}")
   endif()
 
   if(NOT _AMENT_PACKAGE_NAME)


### PR DESCRIPTION
Arguments to a macro are not variables, so it's not
possible to do 'if(ARGN)' to check for arguments;
however, copying ARGN to a variable works.

See https://cmake.org/cmake/help/v3.5/command/if.html (emphasis mine):

> if(<variable|string>)
True if given a variable that is defined to a value that is not a false constant. False otherwise. **(Note macro arguments are not variables.)**

- See also ament/ament_cmake#167
