### PR TITLE
update phrase of status messages

### DIFF
--- a/ament_clang_format/ament_clang_format/main.py
+++ b/ament_clang_format/ament_clang_format/main.py
@@ -209,7 +209,7 @@ def main(argv=sys.argv[1:]):
     file_count = sum(1 if report[k] else 0 for k in report.keys())
     replacement_count = sum(len(r) for r in report.values())
     if not file_count:
-        print('No errors')
+        print('No problems found')
         rc = 0
     else:
         print('%d files with %d code style divergences' %
@@ -348,7 +348,7 @@ def get_xunit_content(report, testname, elapsed):
             xml += """  <testcase
     name=%(quoted_location)s
     classname="%(testname)s"
-    status="No errors"/>
+    status="No problems found"/>
 """ % data
 
     # output list of checked files

--- a/ament_copyright/ament_copyright/main.py
+++ b/ament_copyright/ament_copyright/main.py
@@ -188,7 +188,7 @@ def main(argv=sys.argv[1:]):
     # output summary
     error_count = len([r for r in report if not r[1]])
     if not error_count:
-        print('No errors, checked %d files' % len(report))
+        print('No problems found, checked %d files' % len(report))
         rc = 0
     else:
         print('%d errors, checked %d files' % (error_count, len(report)), file=sys.stderr)

--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -135,7 +135,7 @@ def main(argv=sys.argv[1:]):
     # output summary
     error_count = sum(len(r) for r in report.values())
     if not error_count:
-        print('No errors')
+        print('No problems found')
         rc = 0
     else:
         print('%d errors' % error_count, file=sys.stderr)
@@ -242,7 +242,7 @@ def get_xunit_content(report, testname, elapsed):
             xml += """  <testcase
     name=%(quoted_location)s
     classname="%(testname)s"
-    status="No errors"/>
+    status="No problems found"/>
 """ % data
 
     # output list of checked files

--- a/ament_cpplint/ament_cpplint/main.py
+++ b/ament_cpplint/ament_cpplint/main.py
@@ -175,7 +175,7 @@ def main(argv=sys.argv[1:]):
         print('Total errors found: %d' % _cpplint_state.error_count,
               file=sys.stderr)
     else:
-        print('No errors found')
+        print('No problems found')
 
     # generate xunit file
     if args.xunit_file:
@@ -315,7 +315,7 @@ def get_xunit_content(report, testname, elapsed):
             xml += """  <testcase
     name=%(quoted_location)s
     classname="%(testname)s"
-    status="No errors"/>
+    status="No problems found"/>
 """ % data
 
     # output list of checked files

--- a/ament_flake8/ament_flake8/main.py
+++ b/ament_flake8/ament_flake8/main.py
@@ -83,7 +83,7 @@ def main(argv=sys.argv[1:]):
     print('')
     print('%d files checked' % len(report.files))
     if not report.total_errors:
-        print('No errors or warnings')
+        print('No problems found')
         rc = 0
     else:
         print('%d errors' % (report.total_errors))
@@ -224,7 +224,7 @@ def get_xunit_content(report, testname, elapsed):
         xml += """  <testcase
     name="flake8"
     classname="%(testname)s"
-    status="No errors or warnings"/>
+    status="No problems found"/>
 """ % data
 
     # output list of checked files

--- a/ament_lint_cmake/ament_lint_cmake/main.py
+++ b/ament_lint_cmake/ament_lint_cmake/main.py
@@ -92,7 +92,7 @@ def main(argv=sys.argv[1:]):
     # print summary
     print('')
     if not cmakelint._lint_state.errors:
-        print('No errors')
+        print('No problems found')
         rc = 0
     else:
         print('%d errors' % cmakelint._lint_state.errors)
@@ -193,7 +193,7 @@ def get_xunit_content(report, testname, elapsed):
             xml += """  <testcase
     name=%(quoted_location)s
     classname="%(testname)s"
-    status="No errors"/>
+    status="No problems found"/>
 """ % data
 
     # output list of checked files

--- a/ament_pclint/ament_pclint/main.py
+++ b/ament_pclint/ament_pclint/main.py
@@ -200,7 +200,7 @@ def main(argv=sys.argv[1:]):
     # output summary
     error_count = sum(len(r) for r in report.values())
     if not error_count:
-        print('No errors')
+        print('No problems found')
         rc = 0
     else:
         print('%d errors' % error_count, file=sys.stderr)
@@ -359,7 +359,7 @@ def get_xunit_content(report, testname, elapsed):
             xml += """  <testcase
     name=%(quoted_location)s
     classname="%(testname)s"
-    status="No errors"/>
+    status="No problems found"/>
 """ % data
 
     # output list of checked files

--- a/ament_pep257/ament_pep257/main.py
+++ b/ament_pep257/ament_pep257/main.py
@@ -79,7 +79,7 @@ def main(argv=sys.argv[1:]):
 
     # print summary
     if not error_count:
-        print('No errors')
+        print('No problems found')
         rc = 0
     else:
         print('%d errors' % error_count)
@@ -222,7 +222,7 @@ def get_xunit_content(report, testname, elapsed):
             xml += """  <testcase
     name=%(quoted_location)s
     classname="%(testname)s"
-    status="No errors"/>
+    status="No problems found"/>
 """ % data
 
     # output list of checked files

--- a/ament_pep8/ament_pep8/main.py
+++ b/ament_pep8/ament_pep8/main.py
@@ -74,7 +74,7 @@ def main(argv=sys.argv[1:]):
     # print summary
     print('')
     if not report.total_errors:
-        print('No errors or warnings')
+        print('No problems found')
         rc = 0
     else:
         errors = report.get_count('E')
@@ -163,7 +163,7 @@ def get_xunit_content(report, testname):
         xml += """  <testcase
     name="pep8"
     classname="%(testname)s"
-    status="No errors or warnings"/>
+    status="No problems found"/>
 """ % data
 
     # output list of checked files

--- a/ament_pyflakes/ament_pyflakes/main.py
+++ b/ament_pyflakes/ament_pyflakes/main.py
@@ -78,7 +78,7 @@ def main(argv=sys.argv[1:]):
     # output summary
     error_count = sum(len(r[1]) for r in report)
     if not error_count:
-        print('No errors')
+        print('No problems found')
         rc = 0
     else:
         print('%d errors' % error_count, file=sys.stderr)
@@ -179,7 +179,7 @@ def get_xunit_content(report, testname, elapsed):
             xml += """  <testcase
     name=%(quoted_location)s
     classname="%(testname)s"
-    status="No errors"/>
+    status="No problems found"/>
 """ % data
 
     # output list of checked files

--- a/ament_uncrustify/ament_uncrustify/main.py
+++ b/ament_uncrustify/ament_uncrustify/main.py
@@ -245,7 +245,7 @@ def main(argv=sys.argv[1:]):
     # output summary
     error_count = sum([1 if r[1] else 0 for r in report])
     if not error_count:
-        print('No errors')
+        print('No problems found')
         rc = 0
     else:
         print('%d files with code style divergence' % error_count,
@@ -356,7 +356,7 @@ def get_xunit_content(report, testname, elapsed):
             xml += """  <testcase
     name=%(quoted_location)s
     classname="%(testname)s"
-    status="No errors"/>
+    status="No problems found"/>
 """ % data
 
     # output list of checked files

--- a/ament_xmllint/ament_xmllint/main.py
+++ b/ament_xmllint/ament_xmllint/main.py
@@ -124,7 +124,7 @@ def main(argv=sys.argv[1:]):
     # output summary
     error_count = sum(1 if r[1] else 0 for r in report)
     if not error_count:
-        print('No errors')
+        print('No problems found')
         rc = 0
     else:
         print('%d files are invalid' % error_count, file=sys.stderr)
@@ -252,7 +252,7 @@ def get_xunit_content(report, testname, elapsed):
             xml += """  <testcase
     name=%(quoted_location)s
     classname="%(testname)s"
-    status="No errors"/>
+    status="No problems found"/>
 """ % data
 
     # output list of checked files


### PR DESCRIPTION
Using the terms "error" / "warning" in the status message when no problems were found is problematic when trying to grep through the build output for either of these.

Therefore this patch uses the phrase "No problems found" instead.