### PR TITLE
use explicit encoding when reading files

### DIFF
--- a/ament_copyright/ament_copyright/parser.py
+++ b/ament_copyright/ament_copyright/parser.py
@@ -49,7 +49,7 @@ class FileDescriptor:
     def read(self):
         if not self.exists:
             return
-        with open(self.path, 'r') as h:
+        with open(self.path, 'r', encoding='utf-8') as h:
             self.content = h.read()
 
     def parse(self):

--- a/ament_uncrustify/ament_uncrustify/main.py
+++ b/ament_uncrustify/ament_uncrustify/main.py
@@ -206,8 +206,8 @@ def main(argv=sys.argv[1:]):
         # compute diff
         for index, filename in enumerate(files):
             modified_filename = output_files[index]
-            with open(filename, 'r') as original_file:
-                with open(modified_filename, 'r') as modified_file:
+            with open(filename, 'r', encoding='utf-8') as original_file:
+                with open(modified_filename, 'r', encoding='utf-8') as modified_file:
                     diff_lines = list(difflib.unified_diff(
                         original_file.readlines(), modified_file.readlines(),
                         fromfile=filename, tofile=filename + suffix,


### PR DESCRIPTION
Connect to ros2/rosidl#352.

Addressed linter warnings when files contain non-ASCII character:
* https://ci.ros2.org/job/ci_windows/6719/testReport/junit/(root)/projectroot/copyright/
* https://ci.ros2.org/job/ci_windows/6719/testReport/junit/(root)/projectroot/uncrustify/

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=6728)](https://ci.ros2.org/job/ci_windows/6728/)