### PR TITLE
Fix deprecation warning using raw str

### DIFF
--- a/ament_lint_cmake/ament_lint_cmake/cmakelint.py
+++ b/ament_lint_cmake/ament_lint_cmake/cmakelint.py
@@ -121,7 +121,7 @@ class _CMakePackageState(object):
 
     def _GetExpected(self, filename):
         package = os.path.basename(filename)
-        package = re.sub('^Find(.*)\.cmake', lambda m: m.group(1), package)
+        package = re.sub(r'^Find(.*)\.cmake', lambda m: m.group(1), package)
         return package.upper()
 
     def Done(self, filename, errors):
@@ -332,7 +332,7 @@ def CheckStyle(filename, linenumber, clean_lines, errors):
     CheckRepeatLogic(filename, linenumber, clean_lines, errors)
 
 def CheckFileName(filename, errors):
-    name_match = re.match('Find(.*)\.cmake', os.path.basename(filename))
+    name_match = re.match(r'Find(.*)\.cmake', os.path.basename(filename))
     if name_match:
         package = name_match.group(1)
         if not package.isupper():


### PR DESCRIPTION
This fixes a deprecation warning when building `ament_lint_cmake` on windows 10 using python 3.7.3

```
C:\ros2_ws\build\ament_lint_cmake\build\bdist.win-amd64\egg\ament_lint_cmake\cmakelint.py:124: DeprecationWarning: invalid escape sequence \.
  package = re.sub('^Find(.*)\.cmake', lambda m: m.group(1), package)
C:\ros2_ws\build\ament_lint_cmake\build\bdist.win-amd64\egg\ament_lint_cmake\cmakelint.py:335: DeprecationWarning: invalid escape sequence \.
  name_match = re.match('Find(.*)\.cmake', os.path.basename(filename))
```