### PR TITLE
readd listener if available

### DIFF
--- a/ament_flake8/ament_flake8/main.py
+++ b/ament_flake8/ament_flake8/main.py
@@ -136,6 +136,11 @@ def get_flake8_style_guide(argv):
     application.register_plugin_options()
     application.parse_configuration_and_cli(argv)
     application.make_formatter()
+    try:
+        # needed in older flake8 versions to populate the listener
+        application.make_notifier()
+    except AttributeError:
+        pass
     application.make_guide()
     application.make_file_checker_manager()
     return StyleGuide(application)


### PR DESCRIPTION
Follow up of #124 to work with older `flake8` versions like the one available from Debian on Ubuntu Bionic: e.g. http://build.ros2.org/view/Ddev/job/Ddev__rclpy__ubuntu_bionic_amd64/27/testReport/(root)/rclpy/flake8_xunit_missing_result/