### PR TITLE
Escape backslashes

### DIFF
--- a/ament_cpplint/ament_cpplint/cpplint.py
+++ b/ament_cpplint/ament_cpplint/cpplint.py
@@ -191,7 +191,7 @@ Syntax: cpplint.py [--verbose=#] [--output=vs7] [--filter=-x,+y,...]
 
       Example file:
         filter=-build/include_order,+build/include_alpha
-        exclude_files=.*\.cc
+        exclude_files=.*\\.cc
 
     The above example disables build/include_order warning and enables
     build/include_alpha as well as excludes all .cc from being
@@ -1104,7 +1104,7 @@ class FileInfo(object):
     If we have a real absolute path name here we can try to do something smart:
     detecting the root of the checkout and truncating /path/to/checkout from
     the name so that we get header guards that don't include things like
-    "C:\Documents and Settings\..." or "/home/username/..." in them and thus
+    "C:\\Documents and Settings\\..." or "/home/username/..." in them and thus
     people on different computers who have checked the source out to different
     locations won't see bogus errors.
     """

--- a/ament_lint_cmake/ament_lint_cmake/cmakelint.py
+++ b/ament_lint_cmake/ament_lint_cmake/cmakelint.py
@@ -121,7 +121,7 @@ class _CMakePackageState(object):
 
     def _GetExpected(self, filename):
         package = os.path.basename(filename)
-        package = re.sub('^Find(.*)\.cmake', lambda m: m.group(1), package)
+        package = re.sub(r'^Find(.*)\.cmake', lambda m: m.group(1), package)
         return package.upper()
 
     def Done(self, filename, errors):
@@ -332,7 +332,7 @@ def CheckStyle(filename, linenumber, clean_lines, errors):
     CheckRepeatLogic(filename, linenumber, clean_lines, errors)
 
 def CheckFileName(filename, errors):
-    name_match = re.match('Find(.*)\.cmake', os.path.basename(filename))
+    name_match = re.match(r'Find(.*)\.cmake', os.path.basename(filename))
     if name_match:
         package = name_match.group(1)
         if not package.isupper():


### PR DESCRIPTION
When running on Windows Debug (where all warnings are printed), the backslashes in these strings/comments were causing warnings like:

```
C:\J\workspace\nightly_win_deb\ws\install\Lib\site-packages\ament_cpplint\cpplint.py:1110: DeprecationWarning: invalid escape sequence \D
```

In cpplint.py, escape the backslashes properly (since these are triple-quoted strings).  In cmakelint.py, make the strings raw.