### PR TITLE
Bring clang-format in line with developer guide

### DIFF
--- a/ament_clang_format/ament_clang_format/configuration/.clang-format
+++ b/ament_clang_format/ament_clang_format/configuration/.clang-format
@@ -1,87 +1,12 @@
+---
 Language: Cpp
-# BasedOnStyle: Google
-AccessModifierOffset: -1
-AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: false
-AlignEscapedNewlinesLeft: true
-AlignOperands: true
-AlignTrailingComments: true
-AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: false
-AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: All
-AllowShortIfStatementsOnASingleLine: true
-AllowShortLoopsOnASingleLine: true
-AlwaysBreakAfterDefinitionReturnType: None
-AlwaysBreakAfterReturnType: None
-AlwaysBreakBeforeMultilineStrings: true
-AlwaysBreakTemplateDeclarations: true
-BinPackArguments: true
-BinPackParameters: true
-BraceWrapping:
-  AfterClass: false
-  AfterControlStatement: false
-  AfterEnum: false
-  AfterFunction: false
-  AfterNamespace: false
-  AfterObjCDeclaration: false
-  AfterStruct: false
-  AfterUnion: false
-  BeforeCatch: false
-  BeforeElse: false
-  IndentBraces: false
-BreakBeforeBinaryOperators: None
-BreakBeforeBraces: Attach
-BreakBeforeTernaryOperators: true
-BreakConstructorInitializersBeforeComma: false
-ColumnLimit: 80
-CommentPragmas: '^ IWYU pragma:'
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
-ConstructorInitializerIndentWidth: 4
-ContinuationIndentWidth: 4
-Cpp11BracedListStyle: true
-DerivePointerAlignment: true
-DisableFormat: false
-ExperimentalAutoDetectBinPacking: false
-ForEachMacros: [ foreach, Q_FOREACH, BOOST_FOREACH ]
-IncludeCategories:
-  - Regex: '^<.*\.h>'
-    Priority: 1
-  - Regex: '^<.*'
-    Priority: 2
-  - Regex: '.*'
-    Priority: 3
-IndentCaseLabels: true
-IndentWidth: 2
-IndentWrappedFunctionNames: false
-KeepEmptyLinesAtTheStartOfBlocks: false
-MacroBlockBegin: ''
-MacroBlockEnd: ''
-MaxEmptyLinesToKeep: 1
-NamespaceIndentation: None
-ObjCBlockIndentWidth: 2
-ObjCSpaceAfterProperty: false
-ObjCSpaceBeforeProtocolList: false
-PenaltyBreakBeforeFirstCallParameter: 1
-PenaltyBreakComment: 300
-PenaltyBreakFirstLessLess: 120
-PenaltyBreakString: 1000
-PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 200
-PointerAlignment: Left
-ReflowComments: true
-SortIncludes: true
-SpaceAfterCStyleCast: false
-SpaceBeforeAssignmentOperators: true
-SpaceBeforeParens: ControlStatements
-SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 2
-SpacesInAngles: false
-SpacesInContainerLiterals: true
-SpacesInCStyleCastParentheses: false
-SpacesInParentheses: false
-SpacesInSquareBrackets: false
-Standard: Auto
-TabWidth: 8
-UseTab: Never
+BasedOnStyle: Google
+ColumnLimit: 100
+AccessModifierOffset: -2
+DerivePointerAlignment: False
+PointerAlignment: Middle
+BreakBeforeBraces: Linux
+AlignAfterOpenBracket: AlwaysBreak
+ContinuationIndentWidth: 2
+ReflowComments: false
+...

--- a/ament_clang_format/ament_clang_format/configuration/.clang-format
+++ b/ament_clang_format/ament_clang_format/configuration/.clang-format
@@ -1,18 +1,19 @@
 ---
 Language: Cpp
 BasedOnStyle: Google
-ColumnLimit: 100
+
 AccessModifierOffset: -2
+AlignAfterOpenBracket: AlwaysBreak
+BraceWrapping:
+  AfterClass: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+BreakBeforeBraces: Custom
+ColumnLimit: 100
+ConstructorInitializerIndentWidth: 0
+ContinuationIndentWidth: 2
 DerivePointerAlignment: false
 PointerAlignment: Middle
-BreakBeforeBraces: Custom
-BraceWrapping:
-  AfterFunction: true
-  AfterStruct: true
-  AfterClass: true
-  AfterNamespace: true
-AlignAfterOpenBracket: AlwaysBreak
-ContinuationIndentWidth: 2
 ReflowComments: false
-ConstructorInitializerIndentWidth: 0
 ...

--- a/ament_clang_format/ament_clang_format/configuration/.clang-format
+++ b/ament_clang_format/ament_clang_format/configuration/.clang-format
@@ -3,7 +3,7 @@ Language: Cpp
 BasedOnStyle: Google
 ColumnLimit: 100
 AccessModifierOffset: -2
-DerivePointerAlignment: False
+DerivePointerAlignment: false
 PointerAlignment: Middle
 BreakBeforeBraces: Custom
 BraceWrapping:

--- a/ament_clang_format/ament_clang_format/configuration/.clang-format
+++ b/ament_clang_format/ament_clang_format/configuration/.clang-format
@@ -5,7 +5,12 @@ ColumnLimit: 100
 AccessModifierOffset: -2
 DerivePointerAlignment: False
 PointerAlignment: Middle
-BreakBeforeBraces: Linux
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterFunction: true
+  AfterStruct: true
+  AfterClass: true
+  AfterNamespace: true
 AlignAfterOpenBracket: AlwaysBreak
 ContinuationIndentWidth: 2
 ReflowComments: false

--- a/ament_clang_format/ament_clang_format/configuration/.clang-format
+++ b/ament_clang_format/ament_clang_format/configuration/.clang-format
@@ -14,4 +14,5 @@ BraceWrapping:
 AlignAfterOpenBracket: AlwaysBreak
 ContinuationIndentWidth: 2
 ReflowComments: false
+ConstructorInitializerIndentWidth: 0
 ...


### PR DESCRIPTION
Previously, ament_clang_format's defaults were very divergent from ament_uncrustify. Now the default config file has been rewritten to match the developer guide.
https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#id26
