### PR TITLE
Add line break after first open paren in multiline function call

### DIFF
--- a/ament_uncrustify/ament_uncrustify/configuration/ament_code_style.cfg
+++ b/ament_uncrustify/ament_uncrustify/configuration/ament_code_style.cfg
@@ -1361,7 +1361,7 @@ nl_func_def_empty               = ignore   # ignore/add/remove/force
 nl_func_call_empty              = ignore   # ignore/add/remove/force
 
 # Whether to add newline after '(' in a function call if '(' and ')' are in different lines.
-nl_func_call_start_multi_line   = false    # false/true
+nl_func_call_start_multi_line   = true     # false/true
 
 # Whether to add newline after each ',' in a function call if '(' and ')' are in different lines.
 nl_func_call_args_multi_line    = false    # false/true


### PR DESCRIPTION
Update line break behavior to match the developer guide:

https://index.ros.org/doc/ros2/Contributing/Developer-Guide/

>>> When a function call cannot fit on one line, wrap at the open parenthesis (not in between arguments) and start them on the next line with a 2-space indent. Continue with the 2-space indent on subsequent lines for more arguments. (Note that the Google style guide is internally contradictory on this point.)