### PR TITLE
Add missing pyyaml dependency

### DIFF
--- a/ament_clang_format/setup.py
+++ b/ament_clang_format/setup.py
@@ -5,7 +5,7 @@ setup(
     name='ament_clang_format',
     version='0.7.1',
     packages=find_packages(exclude=['test']),
-    install_requires=['setuptools'],
+    install_requires=['setuptools', 'pyyaml'],
     package_data={'': [
         'configuration/.clang-format',
     ]},


### PR DESCRIPTION
ament_clang_format will crash without this dependency with something like:
```
➜ ament_clang_format
Traceback (most recent call last):
  File "/Users/dan/temp/env/bin/ament_clang_format", line 11, in <module>
    load_entry_point('ament-clang-format', 'console_scripts', 'ament_clang_format')()
  File "/Users/dan/temp/env/lib/python3.7/site-packages/pkg_resources/__init__.py", line 489, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/Users/dan/temp/env/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2793, in load_entry_point
    return ep.load()
  File "/Users/dan/temp/env/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2411, in load
    return self.resolve()
  File "/Users/dan/temp/env/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2417, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/Users/dan/temp/ament_lint/ament_clang_format/ament_clang_format/main.py", line 26, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
```