### PR TITLE
Add support for custom config

### DIFF
--- a/ament_clang_format/ament_clang_format/main.py
+++ b/ament_clang_format/ament_clang_format/main.py
@@ -31,6 +31,13 @@ def main(argv=sys.argv[1:]):
         os.path.dirname(__file__), 'configuration', '.clang-format')
     extensions = ['c', 'cc', 'cpp', 'cxx', 'h', 'hh', 'hpp', 'hxx']
 
+    custom_config_file = os.path.join(
+        os.getcwd(), '.clang-format')
+
+    if os.path.exists(custom_config_file):
+        print('Found custom config file')
+        config_file = custom_config_file
+
     parser = argparse.ArgumentParser(
         description='Check code style using clang_format.',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)


### PR DESCRIPTION
Currently `.clang-format` is only taken from the `configuration` folder.  This PR adds support for utilization of a custom config file if found in the directory from which `ament_clang_format` is called.