### PR TITLE
Match copyright templates with differing whitespace

### DIFF
--- a/ament_copyright/ament_copyright/parser.py
+++ b/ament_copyright/ament_copyright/parser.py
@@ -60,12 +60,12 @@ class FileDescriptor:
             return
 
         for name, license_ in get_licenses().items():
-            template = getattr(license_, license_part).replace('\n', ' ').strip()
+            template = remove_formatting(getattr(license_, license_part))
             last_index = -1
             for license_section in template.split('{copyright_holder}'):
                 # OK, now look for each section of the license in the incoming
                 # content.
-                index = content.replace('\n', ' ').strip().find(license_section.strip())
+                index = remove_formatting(content).find(license_section.strip())
                 if index == -1 or index <= last_index:
                     # Some part of the license is not in the content, or the license
                     # is rearranged, this license doesn't match.
@@ -280,3 +280,7 @@ def scan_past_empty_lines(content, index):
 
 def is_empty_line(content, index):
     return get_index_of_next_line(content, index) == index + 1
+
+
+def remove_formatting(text):
+    return ' '.join(filter(None, text.split()))

--- a/ament_copyright/test/cases/bsd_license/case.py
+++ b/ament_copyright/test/cases/bsd_license/case.py
@@ -1,0 +1,31 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+# All rights reserved.
+#
+# Software License Agreement (BSD License 2.0)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.

--- a/ament_copyright/test/cases/bsd_license_indented/case.py
+++ b/ament_copyright/test/cases/bsd_license_indented/case.py
@@ -1,0 +1,31 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+# All rights reserved.
+#
+# Software License Agreement (BSD License 2.0)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above
+#      copyright notice, this list of conditions and the following
+#      disclaimer in the documentation and/or other materials provided
+#      with the distribution.
+#    * Neither the name of the copyright holder nor the names of its
+#      contributors may be used to endorse or promote products derived
+#      from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.

--- a/ament_copyright/test/cases/bsd_license_tabs/case.py
+++ b/ament_copyright/test/cases/bsd_license_tabs/case.py
@@ -1,0 +1,33 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+# All rights reserved.
+#
+# Software License Agreement (BSD License 2.0)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 	* Redistributions of source code must retain the above
+# 	  copyright notice, this list of conditions and the
+# 	  following disclaimer.
+# 	* Redistributions in binary form must reproduce the above
+# 	  copyright notice, this list of conditions and the
+# 	  following disclaimer in the documentation and/or other
+# 	  materials provided with the distribution.
+# 	* Neither the name of the copyright holder nor the names of
+# 	  its contributors may be used to endorse or promote
+# 	  products derived from this software without specific prior
+# 	  written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.

--- a/ament_copyright/test/test_copyright.py
+++ b/ament_copyright/test/test_copyright.py
@@ -1,0 +1,35 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from ament_copyright.main import main
+
+
+cases_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'cases')
+
+
+def test_bsd_standard():
+    rc = main(argv=[os.path.join(cases_path, 'bsd_license')])
+    assert rc == 0, 'Found errors'
+
+
+def test_bsd_indented():
+    rc = main(argv=[os.path.join(cases_path, 'bsd_license_indented')])
+    assert rc == 0, 'Found errors'
+
+
+def test_bsd_tabs():
+    rc = main(argv=[os.path.join(cases_path, 'bsd_license_tabs')])
+    assert rc == 0, 'Found errors'


### PR DESCRIPTION
This change makes the template matching tolerant to more whitespace differences. In particular, it makes it tolerant in the presence of tabs, consecutive spaces (such as indentation) and EOL differences.