### PR TITLE
Add error output, header out option, fix null error

### DIFF
--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -56,6 +56,13 @@ def main(argv=sys.argv[1:]):
         '--xunit-file',
         help='Generate a xunit compliant XML file')
     parser.add_argument(
+        '--header-filter',
+        help='Accepts a regex and displays errors from the specified non-system headers')
+    parser.add_argument(
+        '--system-headers',
+        action='store_true',
+        help='Displays errors from all system headers')
+    parser.add_argument(
         '--export-fixes',
         help='Generate a DAT file of recorded fixes')
     parser.add_argument(
@@ -71,10 +78,6 @@ def main(argv=sys.argv[1:]):
         action='store_true',
         help='Suppresses printing statistics about ignored warnings '
              'and warnings treated as errors')
-    parser.add_argument(
-        '--add-headers',
-        action='store_true',
-        help='Display errors from all non-system headers')
     args = parser.parse_args(argv)
 
     if not os.path.exists(args.config_file):
@@ -107,6 +110,11 @@ def main(argv=sys.argv[1:]):
     style = yaml.dump(data, default_flow_style=True, width=float('inf'))
     cmd = [clang_tidy_bin,
            '--config=%s' % style]
+    if args.header_filter:
+        cmd.append('--header-filter')
+        cmd.append(args.header_filter)
+    if args.system_headers:
+        cmd.append('--system-headers')
     if args.export_fixes:
         cmd.append('--export-fixes')
         cmd.append(args.export_fixes)
@@ -116,8 +124,6 @@ def main(argv=sys.argv[1:]):
         cmd.append('--fix-errors')
     if args.quiet:
         cmd.append('--quiet')
-    if args.add_headers:
-        cmd.append('--header-filter=.*')
     cmd.extend(files)
     cmd.append('--')
     try:

--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -211,14 +211,14 @@ def get_files(paths, extensions):
 
 
 def find_error_message(data):
-    return data[data.rfind(':')+2:]
+    return data[data.rfind(':') + 2:]
 
 
 def find_line_and_col_num(data):
     first_col = data.find(':')
-    second_col = data.find(':', first_col+1)
-    third_col = data.find(':', second_col+1)
-    return data[first_col+1:second_col], data[second_col+1:third_col]
+    second_col = data.find(':', first_col + 1)
+    third_col = data.find(':', second_col + 1)
+    return data[first_col + 1:second_col], data[second_col + 1:third_col]
 
 
 def get_xunit_content(report, testname, elapsed):

--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -66,6 +66,10 @@ def main(argv=sys.argv[1:]):
         '--fix-errors',
         action='store_true',
         help='Fix the suggested changes')
+    parser.add_argument(
+        '--add-headers',
+        action='store_true',
+        help='Display errors from all non-system headers')
     args = parser.parse_args(argv)
 
     if not os.path.exists(args.config_file):
@@ -100,6 +104,8 @@ def main(argv=sys.argv[1:]):
            '--config=%s' % style]
     if args.explain_config:
         cmd.append('--explain-config')
+    if args.add_headers:
+        cmd.append('--header-filter=.*')
     if args.fix_errors:
         cmd.append('--fix-errors')
     if args.export_fixes:
@@ -109,6 +115,7 @@ def main(argv=sys.argv[1:]):
     cmd.append('--')
     try:
         output = subprocess.check_output(cmd).strip().decode()
+        print(output)
     except subprocess.CalledProcessError as e:
         print("The invocation of '%s' failed with error code %d: %s" %
               (os.path.basename(clang_tidy_bin), e.returncode, e),
@@ -149,8 +156,8 @@ def main(argv=sys.argv[1:]):
             data['error_msg'] = error_msg
         else:
             data['code_correct_rec'] = data.get('code_correct_rec', '') + line + '\n'
-
-    report[current_file].append(copy.deepcopy(data))
+    if current_file is not None:
+        report[current_file].append(copy.deepcopy(data))
 
     if args.xunit_file:
         folder_name = os.path.basename(os.path.dirname(args.xunit_file))

--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -53,31 +53,31 @@ def main(argv=sys.argv[1:]):
     # not using a file handle directly
     # in order to prevent leaving an empty file when something fails early
     parser.add_argument(
-        '--xunit-file',
-        help='Generate a xunit compliant XML file')
-    parser.add_argument(
-        '--header-filter',
-        help='Accepts a regex and displays errors from the specified non-system headers')
-    parser.add_argument(
-        '--system-headers',
-        action='store_true',
-        help='Displays errors from all system headers')
-    parser.add_argument(
-        '--export-fixes',
-        help='Generate a DAT file of recorded fixes')
-    parser.add_argument(
         '--explain-config',
         action='store_true',
         help='Explain the enabled checks')
+    parser.add_argument(
+        '--export-fixes',
+        help='Generate a DAT file of recorded fixes')
     parser.add_argument(
         '--fix-errors',
         action='store_true',
         help='Fix the suggested changes')
     parser.add_argument(
+        '--header-filter',
+        help='Accepts a regex and displays errors from the specified non-system headers')
+    parser.add_argument(
         '--quiet',
         action='store_true',
         help='Suppresses printing statistics about ignored warnings '
              'and warnings treated as errors')
+    parser.add_argument(
+        '--system-headers',
+        action='store_true',
+        help='Displays errors from all system headers')
+    parser.add_argument(
+        '--xunit-file',
+        help='Generate a xunit compliant XML file')
     args = parser.parse_args(argv)
 
     if not os.path.exists(args.config_file):
@@ -110,20 +110,20 @@ def main(argv=sys.argv[1:]):
     style = yaml.dump(data, default_flow_style=True, width=float('inf'))
     cmd = [clang_tidy_bin,
            '--config=%s' % style]
-    if args.header_filter:
-        cmd.append('--header-filter')
-        cmd.append(args.header_filter)
-    if args.system_headers:
-        cmd.append('--system-headers')
+    if args.explain_config:
+        cmd.append('--explain-config')
     if args.export_fixes:
         cmd.append('--export-fixes')
         cmd.append(args.export_fixes)
-    if args.explain_config:
-        cmd.append('--explain-config')
     if args.fix_errors:
         cmd.append('--fix-errors')
+    if args.header_filter:
+        cmd.append('--header-filter')
+        cmd.append(args.header_filter)
     if args.quiet:
         cmd.append('--quiet')
+    if args.system_headers:
+        cmd.append('--system-headers')
     cmd.extend(files)
     cmd.append('--')
     try:

--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -67,6 +67,11 @@ def main(argv=sys.argv[1:]):
         action='store_true',
         help='Fix the suggested changes')
     parser.add_argument(
+        '--quiet',
+        action='store_true',
+        help='Suppresses printing statistics about ignored warnings '
+             'and warnings treated as errors')
+    parser.add_argument(
         '--add-headers',
         action='store_true',
         help='Display errors from all non-system headers')
@@ -102,15 +107,17 @@ def main(argv=sys.argv[1:]):
     style = yaml.dump(data, default_flow_style=True, width=float('inf'))
     cmd = [clang_tidy_bin,
            '--config=%s' % style]
-    if args.explain_config:
-        cmd.append('--explain-config')
-    if args.add_headers:
-        cmd.append('--header-filter=.*')
-    if args.fix_errors:
-        cmd.append('--fix-errors')
     if args.export_fixes:
         cmd.append('--export-fixes')
         cmd.append(args.export_fixes)
+    if args.explain_config:
+        cmd.append('--explain-config')
+    if args.fix_errors:
+        cmd.append('--fix-errors')
+    if args.quiet:
+        cmd.append('--quiet')
+    if args.add_headers:
+        cmd.append('--header-filter=.*')
     cmd.extend(files)
     cmd.append('--')
     try:

--- a/ament_clang_tidy/doc/index.rst
+++ b/ament_clang_tidy/doc/index.rst
@@ -14,24 +14,24 @@ How to run the check from the command line?
 
     ament_clang_tidy [<path> ...]
 
-When using the option ``--fix-errors`` the proposed changes are
-applied in place.
-
 The ``--explain-config`` option will explain the origin of the enabled
 configuration checks.
+
+The ``--export-fixes`` option will generate a DAT file of the recorded
+fixes when supplied with a file name.
+
+When using the option ``--fix-errors`` the proposed changes are
+applied in place.
 
 The ``--header-filter`` option will accept a regex and display errors from
 the specified non-system header files.  To display errors from all non-system
 header, use ``--header-filter='.*'``.
 
-The ``--system-headers`` option will display errors from all system header
-files.
-
 The ``--quiet`` option will suppress printing statistics about ignored
 warnings and warnings treated as errors.
 
-The ``--export-fixes`` option will generate a DAT file of the recorded
-fixes when supplied with a file name.
+The ``--system-headers`` option will display errors from all system header
+files.
 
 The ``--xunit-file`` option will generate a xunit compliant XML file when
 supplied with a file name.

--- a/ament_clang_tidy/doc/index.rst
+++ b/ament_clang_tidy/doc/index.rst
@@ -23,6 +23,9 @@ configuration checks.
 The ``--add-headers`` option will display errors from all non-system
 headers.
 
+The ``--quiet`` option will suppress printing statistics about ignored
+warnings and warnings treated as errors.
+
 How to run the check from within a CMake ament package as part of the tests?
 ----------------------------------------------------------------------------
 

--- a/ament_clang_tidy/doc/index.rst
+++ b/ament_clang_tidy/doc/index.rst
@@ -20,11 +20,21 @@ applied in place.
 The ``--explain-config`` option will explain the origin of the enabled
 configuration checks.
 
-The ``--add-headers`` option will display errors from all non-system
-headers.
+The ``--header-filter`` option will accept a regex and display errors from
+the specified non-system header files.  To display errors from all non-system
+header, use ``--header-filter='.*'``.
+
+The ``--system-headers`` option will display errors from all system header
+files.
 
 The ``--quiet`` option will suppress printing statistics about ignored
 warnings and warnings treated as errors.
+
+The ``--export-fixes`` option will generate a DAT file of the recorded
+fixes when supplied with a file name.
+
+The ``--xunit-file`` option will generate a xunit compliant XML file when
+supplied with a file name.
 
 How to run the check from within a CMake ament package as part of the tests?
 ----------------------------------------------------------------------------

--- a/ament_clang_tidy/doc/index.rst
+++ b/ament_clang_tidy/doc/index.rst
@@ -20,6 +20,8 @@ applied in place.
 The ``--explain-config`` option will explain the origin of the enabled
 configuration checks.
 
+The ``--add-headers`` option will display errors from all non-system
+headers.
 
 How to run the check from within a CMake ament package as part of the tests?
 ----------------------------------------------------------------------------


### PR DESCRIPTION
- Add error output to console.
- Add option for user to specify non-system header error output
- Fix bug with referencing `report` dictionary if no files were checked

Fixes #161 

Signed-off-by: John Shepherd <johnshepherd96@yahoo.com>