### PR TITLE
Add python3-yaml depends to ament_clang_tidy/format

### DIFF
--- a/ament_clang_format/package.xml
+++ b/ament_clang_format/package.xml
@@ -10,6 +10,7 @@
   <license>Apache License 2.0</license>
 
   <exec_depend>clang-format</exec_depend>
+  <exec_depend>python3-yaml</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/ament_clang_tidy/package.xml
+++ b/ament_clang_tidy/package.xml
@@ -10,6 +10,7 @@
   <license>Apache License 2.0</license>
 
   <exec_depend>clang-tidy</exec_depend>
+  <exec_depend>python3-yaml</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>


### PR DESCRIPTION
This is added due to a CI build failure (https://github.com/ament/ament_lint/pull/165) that occurs due to pyyaml being added to `setup.py` installation reqs (https://github.com/ament/ament_lint/pull/150) but python3-yaml not existing in `package.xml` as a dependency.

Signed-off-by: John Shepherd <john@openrobotics.org>