### PR TITLE
avoid cppcheck version 1.88 due to performance issues

### DIFF
--- a/ament_cmake_cppcheck/cmake/ament_cppcheck.cmake
+++ b/ament_cmake_cppcheck/cmake/ament_cppcheck.cmake
@@ -58,7 +58,7 @@ function(ament_cppcheck)
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
   if(${cppcheck_version} STREQUAL "1.88")
-    message(WARNING "[ament_cmake_cppcheck] cppcheck 1.88 has known performance issues, skipping")
+    message(STATUS "[ament_cmake_cppcheck] cppcheck 1.88 has known performance issues, skipping")
     set(SHOULD_SKIP "SKIP_TEST")
   endif()
 

--- a/ament_cmake_cppcheck/cmake/ament_cppcheck.cmake
+++ b/ament_cmake_cppcheck/cmake/ament_cppcheck.cmake
@@ -51,6 +51,17 @@ function(ament_cppcheck)
     list(APPEND cmd "--language" "${ARG_LANGUAGE}")
   endif()
 
+  set(SHOULD_SKIP "")
+  execute_process(
+    COMMAND "${ament_cppcheck_BIN}" "--cppcheck-version"
+    OUTPUT_VARIABLE cppcheck_version
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  if(${cppcheck_version} STREQUAL "1.88")
+    message(WARNING "[ament_cmake_cppcheck] cppcheck 1.88 has known performance issues, skipping")
+    set(SHOULD_SKIP "SKIP_TEST")
+  endif()
+
   file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/ament_cppcheck")
   ament_add_test(
     "${ARG_TESTNAME}"
@@ -59,6 +70,7 @@ function(ament_cppcheck)
     OUTPUT_FILE "${CMAKE_BINARY_DIR}/ament_cppcheck/${ARG_TESTNAME}.txt"
     RESULT_FILE "${result_file}"
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    ${SHOULD_SKIP}
   )
   set_tests_properties(
     "${ARG_TESTNAME}"


### PR DESCRIPTION
I'm opening this as a possible solution to the cppcheck 1.88 issues we've been seeing, see: https://github.com/ros2/build_cop/issues/220#issuecomment-516583296

This isn't ideal as our build machines will not be checking cppcheck during this period until a new fixed version of cppcheck is available (master already has fixes), and the same will be true for our users who may install cppcheck, but won't get checking until 1.88+.

However, it avoids the need for us to modify the installation instructions and instruct people to pin or install older versions of cppcheck only to remove those instructions again when 1.88+ is available (hopefully soon).

It modifies the CLI to print a message and return `188`, e.g.:

```
% ament_cppcheck --include_dirs ./include ./test
cppcheck 1.88 has known performance issues and therefore will not be used, set the AMENT_CPPCHECK_ALLOW_1_88 environment variable to override this.
```

As the message implies if you set a specific environment variable you can override that:

```
% AMENT_CPPCHECK_ALLOW_1_88=1 ament_cppcheck --include_dirs ./include ./test
[test/test_subscription_traits.cpp:0]: (error: cppcheckError) Internal error: Child process crashed with signal 9
1 errors
```

Which currently crashes on my computer for `rclcpp`.

If you're using `ament_cmake_cppcheck` then you'll get a CMake warning:

```
--- stderr: rclcpp
CMake Warning at /Users/william/ros2_ws/install/ament_cmake_cppcheck/share/ament_cmake_cppcheck/cmake/ament_cppcheck.cmake:61 (message):
  [ament_cmake_cppcheck] cppcheck 1.88 has known performance issues, skipping
Call Stack (most recent call first):
  /Users/william/ros2_ws/install/ament_cmake_cppcheck/share/ament_cmake_cppcheck/cmake/ament_cmake_cppcheck_lint_hook.cmake:67 (ament_cppcheck)
  /Users/william/ros2_ws/install/ament_cmake_core/share/ament_cmake_core/cmake/core/ament_execute_extensions.cmake:48 (include)
  /Users/william/ros2_ws/install/ament_lint_auto/share/ament_lint_auto/cmake/ament_lint_auto_package_hook.cmake:21 (ament_execute_extensions)
  /Users/william/ros2_ws/install/ament_cmake_core/share/ament_cmake_core/cmake/core/ament_execute_extensions.cmake:48 (include)
  /Users/william/ros2_ws/install/ament_cmake_core/share/ament_cmake_core/cmake/core/ament_package.cmake:66 (ament_execute_extensions)
  CMakeLists.txt:490 (ament_package)


---
Finished <<< rclcpp [7.78s]
```

And the test will "pass":

```
% colcon test --event-handlers console_cohesion+ desktop_notification- --packages-select rclcpp --ctest-args -R cppcheck
Starting >>> rclcpp
--- output: rclcpp
UpdateCTestConfiguration  from :/Users/william/ros2_ws/build/rclcpp/CTestConfiguration.ini
Parse Config file:/Users/william/ros2_ws/build/rclcpp/CTestConfiguration.ini
   Site: kisra
   Build name: (empty)
 Add coverage exclude regular expressions.
SetCTestConfiguration:CMakeCommand:/usr/local/Cellar/cmake/3.13.4/bin/cmake
UpdateCTestConfiguration  from :/Users/william/ros2_ws/build/rclcpp/CTestConfiguration.ini
Parse Config file:/Users/william/ros2_ws/build/rclcpp/CTestConfiguration.ini
Test project /Users/william/ros2_ws/build/rclcpp
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 36
    Start 36: cppcheck

36: Test command: /Users/william/.pyenv/shims/python3 "-u" "/Users/william/ros2_ws/install/ament_cmake_test/share/ament_cmake_test/cmake/run_test.py" "/Users/william/ros2_ws/build/rclcpp/test_results/rclcpp/cppcheck.xunit.xml" "--package-name" "rclcpp" "--skip-test" "--output-file" "/Users/william/ros2_ws/build/rclcpp/ament_cppcheck/cppcheck.txt" "--command" "/Users/william/ros2_ws/install/ament_cppcheck/bin/ament_cppcheck" "--xunit-file" "/Users/william/ros2_ws/build/rclcpp/test_results/rclcpp/cppcheck.xunit.xml" "--include_dirs" "/Users/william/ros2_ws/src/ros2/rclcpp/rclcpp/include" "/Users/william/ros2_ws/src/ros2/rclcpp/rclcpp/test/"
36: Test timeout computed to be: 120
1/1 Test #36: cppcheck .........................   Passed    0.20 sec

The following tests passed:
	cppcheck

100% tests passed, 0 tests failed out of 1

Label Time Summary:
cppcheck    =   0.20 sec*proc (1 test)
linter      =   0.20 sec*proc (1 test)

Total Test time (real) =   0.20 sec
---
Finished <<< rclcpp [1.14s]

Summary: 1 package finished [2.89s]
```

But the test result will show it as skipped:

```
% colcon test-result --test-result-base build/rclcpp --all | grep cppcheck
build/rclcpp/test_results/rclcpp/cppcheck.xunit.xml: 1 test, 0 errors, 0 failures, 1 skipped
```

I'd like to hear from others if they think this is an appropriate workaround for now or not.