### PR TITLE
Fix indent after paren+newline

### DIFF
--- a/ament_uncrustify/ament_uncrustify/configuration/ament_code_style.cfg
+++ b/ament_uncrustify/ament_uncrustify/configuration/ament_code_style.cfg
@@ -954,7 +954,7 @@ indent_align_assign             = false    # false/true
 
 # Align continued statements at the '('. Default=True
 # If FALSE or the '(' is not followed by a newline, the next line indent is one tab.
-indent_align_paren              = true     # false/true
+indent_align_paren              = false     # false/true
 
 # Indent OC blocks at brace level instead of usual rules.
 indent_oc_block                 = false    # false/true


### PR DESCRIPTION
Continuation indent after an open paren by one level instead of aligning to paren.

For some reason, this also prevents wrapping relative to the end of the `throw` keyword as well, even though there's not necessarily a paren there.

Fixes #173

A few examples from rclcpp:
before
```
  result_promise_.set_exception(std::make_exception_ptr(
      exceptions::UnawareGoalHandleError()));
//
    if (ret != RCL_RET_OK) {
      throw std::runtime_error(
              std::string("Couldn't initialize state machine for node ") +
              node_base_interface_->get_name());
//
  using FeedbackCallback =
    std::function<void (
        typename ClientGoalHandle<ActionT>::SharedPtr,
        const std::shared_ptr<const Feedback>)>;
```
after
```
  result_promise_.set_exception(std::make_exception_ptr(
    exceptions::UnawareGoalHandleError()));
//
    if (ret != RCL_RET_OK) {
      throw std::runtime_error(
        std::string("Couldn't initialize state machine for node ") +
        node_base_interface_->get_name());
    }
//
  using FeedbackCallback =
    std::function<void (
      typename ClientGoalHandle<ActionT>::SharedPtr,
      const std::shared_ptr<const Feedback>)>;
```

Signed-off-by: Dan Rose <dan@digilabs.io>