### PR TITLE
re-add path insertion removed from wrong package

### DIFF
--- a/ament_flake8/test/test_flake8.py
+++ b/ament_flake8/test/test_flake8.py
@@ -15,7 +15,9 @@
 import os
 import sys
 
-from ament_flake8.main import main
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from ament_flake8.main import main  # noqa
 
 
 def test_flake8():


### PR DESCRIPTION
fixes removal of path insertion from flake8

Signed-off-by: Ted Kern <ted.kern@canonical.com>