### PR TITLE
Convert list comprehension to generator

### DIFF
--- a/ament_clang_format/ament_clang_format/main.py
+++ b/ament_clang_format/ament_clang_format/main.py
@@ -263,7 +263,7 @@ def get_files(paths, extensions):
                 # select files by extension
                 for filename in sorted(filenames):
                     _, ext = os.path.splitext(filename)
-                    if ext in ['.%s' % e for e in extensions]:
+                    if ext in ('.%s' % e for e in extensions):
                         files.append(os.path.join(dirpath, filename))
         if os.path.isfile(path):
             files.append(path)

--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -216,7 +216,7 @@ def get_files(paths, extensions):
                 # select files by extension
                 for filename in sorted(filenames):
                     _, ext = os.path.splitext(filename)
-                    if ext in ['.%s' % e for e in extensions]:
+                    if ext in ('.%s' % e for e in extensions):
                         files.append(os.path.join(dirpath, filename))
         if os.path.isfile(path):
             files.append(path)

--- a/ament_copyright/ament_copyright/crawler.py
+++ b/ament_copyright/ament_copyright/crawler.py
@@ -70,7 +70,7 @@ def is_repository_root(path):
 def match_filename(filename, extensions):
     """Check if the filename has one of the extensions."""
     _, ext = os.path.splitext(filename)
-    return ext in ['.%s' % e for e in extensions]
+    return ext in ('.%s' % e for e in extensions)
 
 
 def add_files_for_all_filetypes(path, files):

--- a/ament_cpplint/ament_cpplint/main.py
+++ b/ament_cpplint/ament_cpplint/main.py
@@ -215,7 +215,7 @@ def get_file_groups(paths, extensions):
                 # select files by extension
                 for filename in sorted(filenames):
                     _, ext = os.path.splitext(filename)
-                    if ext in ['.%s' % e for e in extensions]:
+                    if ext in ('.%s' % e for e in extensions):
                         append_file_to_group(groups,
                                              os.path.join(dirpath, filename))
         if os.path.isfile(path):

--- a/ament_pclint/ament_pclint/main.py
+++ b/ament_pclint/ament_pclint/main.py
@@ -303,7 +303,7 @@ def get_files(paths, extensions):
                 # select files by extension
                 for filename in sorted(filenames):
                     _, ext = os.path.splitext(filename)
-                    if ext in ['.%s' % e for e in extensions]:
+                    if ext in ('.%s' % e for e in extensions):
                         files.append(os.path.join(dirpath, filename))
         if os.path.isfile(path):
             files.append(path)


### PR DESCRIPTION
Addresses flake8 C412 errors introduced by flake8-comprehension 2.2.0

https://github.com/adamchainz/flake8-comprehensions/blob/master/README.rst#c412-unnecessary-list-comprehension---in-can-take-a-generator

See ros2/build_cop#228

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7867)](http://ci.ros2.org/job/ci_linux/7867/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=3928)](http://ci.ros2.org/job/ci_linux-aarch64/3928/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6420)](http://ci.ros2.org/job/ci_osx/6420/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7727)](http://ci.ros2.org/job/ci_windows/7727/)