### PR TITLE
fix cmake plugin to use correct config file argument keyword

### DIFF
--- a/ament_cmake_mypy/cmake/ament_mypy.cmake
+++ b/ament_cmake_mypy/cmake/ament_mypy.cmake
@@ -38,7 +38,7 @@ function(ament_mypy)
   set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.xunit.xml")
   set(cmd "${ament_mypy_BIN}" "--xunit-file" "${result_file}")
   if(ARG_CONFIG_FILE)
-    list(APPEND cmd "--config-file" "${ARG_CONFIG_FILE}")
+    list(APPEND cmd "--config" "${ARG_CONFIG_FILE}")
   endif()
   list(APPEND cmd ${ARG_UNPARSED_ARGUMENTS})
 


### PR DESCRIPTION
ament_mypy.cmake used wrong flag for passing config files to ament_mypy. Replaced with correct flag. 

Signed-off-by: Ted Kern <ted.kern@canonical.com>