### PR TITLE
install manifest files in Python packages

### DIFF
--- a/ament_clang_format/setup.py
+++ b/ament_clang_format/setup.py
@@ -1,10 +1,15 @@
 from setuptools import find_packages
 from setuptools import setup
 
+package_name = 'ament_clang_format'
+
 setup(
-    name='ament_clang_format',
+    name=package_name,
     version='0.7.4',
     packages=find_packages(exclude=['test']),
+    data_files=[
+        ('share/' + package_name, ['package.xml']),
+    ],
     install_requires=['setuptools', 'pyyaml'],
     package_data={'': [
         'configuration/.clang-format',

--- a/ament_clang_tidy/setup.py
+++ b/ament_clang_tidy/setup.py
@@ -1,10 +1,15 @@
 from setuptools import find_packages
 from setuptools import setup
 
+package_name = 'ament_clang_tidy'
+
 setup(
-    name='ament_clang_tidy',
+    name=package_name,
     version='6.0.0',
     packages=find_packages(exclude=['test']),
+    data_files=[
+        ('share/' + package_name, ['package.xml']),
+    ],
     install_requires=['setuptools', 'pyyaml'],
     package_data={'': [
         'configuration/.clang-tidy',

--- a/ament_copyright/setup.py
+++ b/ament_copyright/setup.py
@@ -1,10 +1,15 @@
 from setuptools import find_packages
 from setuptools import setup
 
+package_name = 'ament_copyright'
+
 setup(
-    name='ament_copyright',
+    name=package_name,
     version='0.7.4',
     packages=find_packages(exclude=['test']),
+    data_files=[
+        ('share/' + package_name, ['package.xml']),
+    ],
     install_requires=['setuptools'],
     package_data={'': [
         'template/*',

--- a/ament_cppcheck/setup.py
+++ b/ament_cppcheck/setup.py
@@ -1,10 +1,15 @@
 from setuptools import find_packages
 from setuptools import setup
 
+package_name = 'ament_cppcheck'
+
 setup(
-    name='ament_cppcheck',
+    name=package_name,
     version='0.7.4',
     packages=find_packages(exclude=['test']),
+    data_files=[
+        ('share/' + package_name, ['package.xml']),
+    ],
     install_requires=['setuptools'],
     zip_safe=True,
     author='Dirk Thomas',

--- a/ament_cpplint/setup.py
+++ b/ament_cpplint/setup.py
@@ -1,10 +1,15 @@
 from setuptools import find_packages
 from setuptools import setup
 
+package_name = 'ament_cpplint'
+
 setup(
-    name='ament_cpplint',
+    name=package_name,
     version='0.7.4',
     packages=find_packages(exclude=['test']),
+    data_files=[
+        ('share/' + package_name, ['package.xml']),
+    ],
     install_requires=['setuptools'],
     zip_safe=True,
     author='Dirk Thomas',

--- a/ament_lint/setup.py
+++ b/ament_lint/setup.py
@@ -1,10 +1,15 @@
 from setuptools import find_packages
 from setuptools import setup
 
+package_name = 'ament_lint'
+
 setup(
-    name='ament_lint',
+    name=package_name,
     version='0.7.4',
     packages=find_packages(exclude=['test']),
+    data_files=[
+        ('share/' + package_name, ['package.xml']),
+    ],
     install_requires=['setuptools'],
     zip_safe=True,
     author='Dirk Thomas',

--- a/ament_lint_cmake/setup.py
+++ b/ament_lint_cmake/setup.py
@@ -1,10 +1,15 @@
 from setuptools import find_packages
 from setuptools import setup
 
+package_name = 'ament_lint_cmake'
+
 setup(
-    name='ament_lint_cmake',
+    name=package_name,
     version='0.7.4',
     packages=find_packages(exclude=['test']),
+    data_files=[
+        ('share/' + package_name, ['package.xml']),
+    ],
     install_requires=['setuptools'],
     zip_safe=True,
     author='Dirk Thomas',

--- a/ament_mypy/setup.py
+++ b/ament_mypy/setup.py
@@ -1,10 +1,15 @@
 from setuptools import find_packages
 from setuptools import setup
 
+package_name = 'ament_mypy'
+
 setup(
-    name='ament_mypy',
+    name=package_name,
     version='0.7.3',
     packages=find_packages(exclude=['test']),
+    data_files=[
+        ('share/' + package_name, ['package.xml']),
+    ],
     install_requires=['setuptools'],
     package_data={'': [
         'configuration/ament_mypy.ini',

--- a/ament_pclint/setup.py
+++ b/ament_pclint/setup.py
@@ -1,10 +1,15 @@
 from setuptools import find_packages
 from setuptools import setup
 
+package_name = 'ament_pclint'
+
 setup(
-    name='ament_pclint',
+    name=package_name,
     version='0.7.4',
     packages=find_packages(exclude=['test']),
+    data_files=[
+        ('share/' + package_name, ['package.xml']),
+    ],
     install_requires=['setuptools'],
     package_data={'': [
         'config/gcc/co-g++.h',

--- a/ament_pep257/setup.py
+++ b/ament_pep257/setup.py
@@ -1,10 +1,15 @@
 from setuptools import find_packages
 from setuptools import setup
 
+package_name = 'ament_pep257'
+
 setup(
-    name='ament_pep257',
+    name=package_name,
     version='0.7.4',
     packages=find_packages(exclude=['test']),
+    data_files=[
+        ('share/' + package_name, ['package.xml']),
+    ],
     install_requires=['setuptools'],
     package_data={'': [
         'configuration/ament_pep257.ini',

--- a/ament_pep8/setup.py
+++ b/ament_pep8/setup.py
@@ -1,10 +1,15 @@
 from setuptools import find_packages
 from setuptools import setup
 
+package_name = 'ament_pep8'
+
 setup(
-    name='ament_pep8',
+    name=package_name,
     version='0.7.4',
     packages=find_packages(exclude=['test']),
+    data_files=[
+        ('share/' + package_name, ['package.xml']),
+    ],
     install_requires=['setuptools'],
     package_data={'': [
         'configuration/ament_pep8.ini',

--- a/ament_pyflakes/setup.py
+++ b/ament_pyflakes/setup.py
@@ -1,10 +1,15 @@
 from setuptools import find_packages
 from setuptools import setup
 
+package_name = 'ament_pyflakes'
+
 setup(
-    name='ament_pyflakes',
+    name=package_name,
     version='0.7.4',
     packages=find_packages(exclude=['test']),
+    data_files=[
+        ('share/' + package_name, ['package.xml']),
+    ],
     install_requires=['setuptools'],
     zip_safe=True,
     author='Dirk Thomas',

--- a/ament_uncrustify/setup.py
+++ b/ament_uncrustify/setup.py
@@ -1,10 +1,15 @@
 from setuptools import find_packages
 from setuptools import setup
 
+package_name = 'ament_uncrustify'
+
 setup(
-    name='ament_uncrustify',
+    name=package_name,
     version='0.7.4',
     packages=find_packages(exclude=['test']),
+    data_files=[
+        ('share/' + package_name, ['package.xml']),
+    ],
     install_requires=['setuptools'],
     package_data={'': [
         'configuration/ament_code_style.cfg',

--- a/ament_xmllint/setup.py
+++ b/ament_xmllint/setup.py
@@ -1,10 +1,15 @@
 from setuptools import find_packages
 from setuptools import setup
 
+package_name = 'ament_xmllint'
+
 setup(
-    name='ament_xmllint',
+    name=package_name,
     version='0.7.4',
     packages=find_packages(exclude=['test']),
+    data_files=[
+        ('share/' + package_name, ['package.xml']),
+    ],
     install_requires=['setuptools'],
     zip_safe=True,
     author='Dirk Thomas',


### PR DESCRIPTION
Otherwise an overlay workspace can't determine the necessary dependencies for an installed underlay.

E.g. needed to pass CI on ros-infrastructure/ros_buildfarm#675 which worked before the colcon/colcon-ros#74.