### PR TITLE
Use relative include path in cppcheck call. Close #177

### DIFF
--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -138,7 +138,7 @@ def main(argv=sys.argv[1:]):
     if args.language:
         cmd.extend(['--language={0}'.format(args.language)])
     for include_dir in (args.include_dirs or []):
-        cmd.extend(['-I', include_dir])
+        cmd.extend(['-I', os.path.relpath(include_dir, os.curdir)])
     if jobs:
         cmd.extend(['-j', '%d' % jobs])
     cmd.extend(files)


### PR DESCRIPTION
This PR replace the absolute path of `-I <path>` in the `cppcheck` call with relative path. 

After upgrading to ROS Melodic, the `cppcheck` version coming from ubuntu bionic source is by default 1.82, which is incompatible with `ament_cppcheck` script. 

When I `colcon test --packages-select xxx --ctest-args -R cppcheck` on a package, I got this error:

```
3: Test command: /usr/bin/python3 "-u" "/home/myname/workspace/install/share/ament_cmake_test/cmake/run_test.py" "/home/myname/workspace/build/cpputils/test_results/cpputils/cppchec
k.xunit.xml" "--package-name" "cpputils" "--output-file" "/home/myname/workspace/build/cpputils/ament_cppcheck/cppcheck.txt" "--command" "/home/myname/workspace/install/bin/ament_cp
pcheck" "--xunit-file" "/home/myname/workspace/build/cpputils/test_results/cpputils/cppcheck.xunit.xml" "--include_dirs" "/home/myname/workspace/src/os/core/cpputils/include"
3: Test timeout computed to be: 120
3: -- run_test.py: invoking following command in '/home/myname/workspace/src/os/core/cpputils':
3:  - /home/myname/workspace/install/bin/ament_cppcheck --xunit-file /home/myname/workspace/build/cpputils/test_results/cpputils/cppcheck.xunit.xml --include_dirs /home/myname/
workspace/src/os/core/cpputils/include
3: [include/cpputils/common_exceptions.hpp:34]: (error: uninitvar) Uninitialized variable: a
3: Traceback (most recent call last):
3:   File "/home/myname/workspace/install/bin/ament_cppcheck", line 11, in <module>
3:     load_entry_point('ament-cppcheck', 'console_scripts', 'ament_cppcheck')()
3:   File "/home/myname/workspace/build/ament_cppcheck/ament_cppcheck/main.py", line 173, in main
3:     report[filename].append(data)
3: KeyError: '/home/myname/workspace/src/os/core/cpputils/include/cpputils/common_exceptions.hpp'
3: -- run_test.py: return code 1
3: -- run_test.py: generate result file '/home/myname/workspace/build/cpputils/test_results/cpputils/cppcheck.xunit.xml' with failed test
3: -- run_test.py: verify result file '/home/myname/workspace/build/cpputils/test_results/cpputils/cppcheck.xunit.xml'
1/1 Test #3: cppcheck .........................***Failed    0.49 sec
```

This is because after `cppcheck 1.82`, violations in the include folder (using `-I <path>`) is also reported in the xml result with absolute path. But `ament_cppcheck` isn't ready to handle absolute as of now. 


```bash
/usr/bin/cppcheck \
-f --inline-suppr -q -rp --xml --xml-version=2 \
-I /home/myname/workspace/src/os/core/cpputils/include \
-j 12 \
include/cpputils/common_exceptions.hpp \
include/cpputils/error_handler.hpp \
include/cpputils/optional.hpp \
include/cpputils/optional_traits.hpp \
include/cpputils/outcome.hpp \
include/cpputils/safe_cast.hpp \
include/cpputils/strerror.hpp \
include/cpputils/string_view.hpp \
include/cpputils/tuple.hpp \
include/cpputils/type_traits.hpp \
include/cpputils/variant.hpp \
include/cpputils/variant_traits.hpp \
src/strerror.cpp \
test/test.cpp \
test/test_common_exceptions.cpp \
test/test_error_handler.cpp \
test/test_outcome.cpp \
test/test_safe_cast.cpp \
test/test_strerror.cpp
<?xml version="1.0" encoding="UTF-8"?>
<results version="2">
    <cppcheck version="1.82"/>
    <errors>
        <error id="uninitvar" severity="error" msg="Uninitialized variable: a" verbose="Uninitialized variable: a" cwe="908">
            <location file="include/cpputils/common_exceptions.hpp" line="34"/>
        </error>
        <error id="uninitvar" severity="error" msg="Uninitialized variable: a" verbose="Uninitialized variable: a" cwe="908">
            <location file="/home/myname/workspace/src/os/core/cpputils/include/cpputils/common_exceptions.hpp" line="34"/>
        </error>
    </errors>
</results>

/==========================Use relative path==========================/

/usr/bin/cppcheck \
-f --inline-suppr -q -rp --xml --xml-version=2 \
-I include \
-j 12 \
include/cpputils/common_exceptions.hpp \
include/cpputils/error_handler.hpp \
include/cpputils/optional.hpp \
include/cpputils/optional_traits.hpp \
include/cpputils/outcome.hpp \
include/cpputils/safe_cast.hpp \
include/cpputils/strerror.hpp \
include/cpputils/string_view.hpp \
include/cpputils/tuple.hpp \
include/cpputils/type_traits.hpp \
include/cpputils/variant.hpp \
include/cpputils/variant_traits.hpp \
src/strerror.cpp \
test/test.cpp \
test/test_common_exceptions.cpp \
test/test_error_handler.cpp \
test/test_outcome.cpp \
test/test_safe_cast.cpp \
test/test_strerror.cpp
<?xml version="1.0" encoding="UTF-8"?>
<results version="2">
    <cppcheck version="1.82"/>
    <errors>
        <error id="uninitvar" severity="error" msg="Uninitialized variable: a" verbose="Uninitialized variable: a" cwe="908">
            <location file="include/cpputils/common_exceptions.hpp" line="34"/>
        </error>
    </errors>
</results>
```