### PR TITLE
fix handling mixed relative/absolute path in ament_cppcheck

### DIFF
--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -170,7 +170,12 @@ def main(argv=sys.argv[1:]):
             'severity': error.get('severity'),
             'msg': error.get('verbose'),
         }
-        report[filename].append(data)
+        if os.path.relpath(os.path.realpath(filename)) in report:
+            filename = os.path.relpath(os.path.realpath(filename))
+        # in the case where relative and absolute paths are mixed for paths and
+        # include_dirs cppcheck might return duplicate results
+        if not any(data == d for d in report[filename]):
+            report[filename].append(data)
 
         data = dict(data)
         data['filename'] = filename

--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -170,8 +170,10 @@ def main(argv=sys.argv[1:]):
             'severity': error.get('severity'),
             'msg': error.get('verbose'),
         }
-        if os.path.relpath(os.path.realpath(filename)) in report:
-            filename = os.path.relpath(os.path.realpath(filename))
+        for key in report.keys():
+            if os.path.samefile(key, filename):
+                filename = key
+                break
         # in the case where relative and absolute paths are mixed for paths and
         # include_dirs cppcheck might return duplicate results
         if data not in report[filename]:

--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -179,10 +179,10 @@ def main(argv=sys.argv[1:]):
         if data not in report[filename]:
             report[filename].append(data)
 
-        data = dict(data)
-        data['filename'] = filename
-        print('[%(filename)s:%(line)d]: (%(severity)s: %(id)s) %(msg)s' % data,
-              file=sys.stderr)
+            data = dict(data)
+            data['filename'] = filename
+            print('[%(filename)s:%(line)d]: (%(severity)s: %(id)s) %(msg)s' % data,
+                file=sys.stderr)
 
     # output summary
     error_count = sum(len(r) for r in report.values())

--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -174,7 +174,7 @@ def main(argv=sys.argv[1:]):
             filename = os.path.relpath(os.path.realpath(filename))
         # in the case where relative and absolute paths are mixed for paths and
         # include_dirs cppcheck might return duplicate results
-        if not any(data == d for d in report[filename]):
+        if data not in report[filename]:
             report[filename].append(data)
 
         data = dict(data)


### PR DESCRIPTION
Replaces #187. Fixes #177.