### PR TITLE
fix pytest warning about unknown markers

### DIFF
--- a/ament_pyflakes/pytest.ini
+++ b/ament_pyflakes/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    linter: marks tests as linter checks
+    pep8: marks tests checking for pep8 compliance


### PR DESCRIPTION
The package doesn't depend on `ament_lint` / `ament_pep8` so these markers aren't defined. Since we still want to use them to select subset of tests and don't want to add a dependency for it this patch simply declares them for `pytest`.

Similar to ament/ament_package#88.