### PR TITLE
Behave better in multi-project cmake

### DIFF
--- a/ament_cmake_cppcheck/cmake/ament_cmake_cppcheck_lint_hook.cmake
+++ b/ament_cmake_cppcheck/cmake/ament_cmake_cppcheck_lint_hook.cmake
@@ -35,7 +35,7 @@ if(_source_files)
 
   # BUILDSYSTEM_TARGETS only supported in CMake >= 3.7
   if(NOT CMAKE_VERSION VERSION_LESS "3.7.0")
-    get_directory_property(_build_targets DIRECTORY ${CMAKE_SOURCE_DIR} BUILDSYSTEM_TARGETS)
+    get_directory_property(_build_targets DIRECTORY ${PROJECT_SOURCE_DIR} BUILDSYSTEM_TARGETS)
     foreach(_target ${_build_targets})
       # Include directories property is different for INTERFACE libraries
       get_target_property(_target_type ${_target} TYPE)
@@ -50,12 +50,12 @@ if(_source_files)
       #     1. Reduces execution time (less include directories to search)
       #     2. cppcheck will not check for errors in external packages
       foreach(_include_dir ${_include_dirs})
-        # TODO(jacobperron): Escape special regex characters in CMAKE_SOURCE_DIR
+        # TODO(jacobperron): Escape special regex characters in PROJECT_SOURCE_DIR
         #                    Related CMake feature request: https://gitlab.kitware.com/cmake/cmake/issues/18409
         # Check if include directory is a subdirectory of the source directory
-        string(REGEX MATCH "^${CMAKE_SOURCE_DIR}/.*" _is_subdirectory ${_include_dir})
+        string(REGEX MATCH "^${PROJECT_SOURCE_DIR}/.*" _is_subdirectory ${_include_dir})
         # Check if include directory is part of a generator expression (e.g. $<BUILD_INTERFACE:...>)
-        string(REGEX MATCH "^\\$<.*:${CMAKE_SOURCE_DIR}/.*>$" _is_genexp_subdirectory "${_include_dir}")
+        string(REGEX MATCH "^\\$<.*:${PROJECT_SOURCE_DIR}/.*>$" _is_genexp_subdirectory "${_include_dir}")
         if(_is_subdirectory OR _is_genexp_subdirectory)
           list_append_unique(_all_include_dirs ${_include_dir})
         endif()


### PR DESCRIPTION
If a sub-project uses ament_lint, don't apply it to the top-level project headers
