### PR TITLE
Ignore pydocstyle D401.

### DIFF
--- a/ament_pep257/ament_pep257/main.py
+++ b/ament_pep257/ament_pep257/main.py
@@ -47,7 +47,7 @@ def main(argv=sys.argv[1:]):
         nargs='*',
         default=[
             'D100', 'D101', 'D102', 'D103', 'D104', 'D105', 'D106', 'D107',
-            'D203', 'D212', 'D404',
+            'D203', 'D212', 'D401', 'D404',
         ],
         help='The pep257 categories to ignore')
     parser.add_argument(


### PR DESCRIPTION
pydocstyle 5.0.0 fixed this check which many of our docstrings are now
failing. There is an ongoing discussion about whether or not we want to
follow it.

This is a straw-man to disable it assuming the answer is not yes.

Closes https://github.com/ros2/build_cop/issues/255