### PR TITLE
Changing uncrustify config option which fixes nested templates.

### DIFF
--- a/ament_uncrustify/ament_uncrustify/configuration/ament_code_style.cfg
+++ b/ament_uncrustify/ament_uncrustify/configuration/ament_code_style.cfg
@@ -25,7 +25,7 @@ string_replace_tab_chars        = false    # false/true
 # Allow interpreting '>=' and '>>=' as part of a template in 'void f(list<list<B>>=val);'.
 # If True, 'assert(x<0 && y>=3)' will be broken. Default=False
 # Improvements to template detection may make this option obsolete.
-tok_split_gte                   = false    # false/true
+tok_split_gte                   = true     # false/true
 
 # Override the default ' *INDENT-OFF*' in comments for disabling processing of part of the file.
 disable_processing_cmt          = " *INDENT-OFF*"      # string


### PR DESCRIPTION
Please see the originally-reported issue on `uncrustify` upstream here: 

https://github.com/uncrustify/uncrustify/issues/2613 and the source of the issue: 

https://gitlab.com/autowarefoundation/autoware.auto/AutowareAuto/issues/235

According to the documentation, this can have unintended consequences:

```
# Allow interpreting '>=' and '>>=' as part of a template in 'void f(list<list<B>>=val);'.
# If True, 'assert(x<0 && y>=3)' will be broken. Default=False
# Improvements to template detection may make this option obsolete.
```

So it is definitely worth some discussion and testing.