### PR TITLE
Add support for the 3-Clause BSD license

### DIFF
--- a/ament_copyright/ament_copyright/licenses.py
+++ b/ament_copyright/ament_copyright/licenses.py
@@ -39,6 +39,7 @@ def read_license_data(path, name, prefix):
 
 apache2 = read_license_data(TEMPLATE_DIRECTORY, 'Apache License, Version 2.0', 'apache2')
 bsd2 = read_license_data(TEMPLATE_DIRECTORY, 'BSD License 2.0', 'bsd2')
+bsd_3clause = read_license_data(TEMPLATE_DIRECTORY, '3-Clause BSD License', 'bsd_3clause')
 mit = read_license_data(TEMPLATE_DIRECTORY, 'MIT License', 'mit')
 gplv3 = read_license_data(TEMPLATE_DIRECTORY, 'GNU General Public License 3.0', 'gplv3')
 lgplv3 = read_license_data(TEMPLATE_DIRECTORY, 'GNU Lesser General Public License 3.0', 'lgplv3')

--- a/ament_copyright/ament_copyright/template/bsd_3clause_contributing.txt
+++ b/ament_copyright/ament_copyright/template/bsd_3clause_contributing.txt
@@ -1,0 +1,3 @@
+Any contribution that you make to this repository will
+be under the 3-Clause BSD License, as dictated by that
+[license](https://opensource.org/licenses/BSD-3-Clause).

--- a/ament_copyright/ament_copyright/template/bsd_3clause_header.txt
+++ b/ament_copyright/ament_copyright/template/bsd_3clause_header.txt
@@ -1,4 +1,5 @@
 {copyright}
+
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 

--- a/ament_copyright/ament_copyright/template/bsd_3clause_header.txt
+++ b/ament_copyright/ament_copyright/template/bsd_3clause_header.txt
@@ -1,0 +1,26 @@
+{copyright}
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+   * Neither the name of the {copyright_holder} nor the names of its
+     contributors may be used to endorse or promote products derived from
+     this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/ament_copyright/ament_copyright/template/bsd_3clause_license.txt
+++ b/ament_copyright/ament_copyright/template/bsd_3clause_license.txt
@@ -1,0 +1,25 @@
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+   * Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from
+     this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/ament_copyright/setup.py
+++ b/ament_copyright/setup.py
@@ -42,6 +42,7 @@ The ability to check sources file for copyright and license information.""",
         'ament_copyright.license': [
             'apache2 = ament_copyright.licenses:apache2',
             'bsd2 = ament_copyright.licenses:bsd2',
+            'bsd_3clause = ament_copyright.licenses:bsd_3clause',
             'mit = ament_copyright.licenses:mit',
             'gplv3 = ament_copyright.licenses:gplv3',
             'lgplv3 = ament_copyright.licenses:lgplv3',

--- a/ament_copyright/test/cases/3clause_bsd/case.py
+++ b/ament_copyright/test/cases/3clause_bsd/case.py
@@ -1,0 +1,31 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the the copyright holder nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+def special():
+    pass

--- a/ament_copyright/test/cases/3clause_bsd/case2.cpp
+++ b/ament_copyright/test/cases/3clause_bsd/case2.cpp
@@ -1,0 +1,34 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+
+int main()
+{
+  std::cout << "Hello World!" << std::endl;
+  return 0;
+}

--- a/ament_copyright/test/cases/3clause_bsd/case2.cpp
+++ b/ament_copyright/test/cases/3clause_bsd/case2.cpp
@@ -29,6 +29,5 @@
 
 int main()
 {
-  std::cout << "Hello World!" << std::endl;
   return 0;
 }

--- a/ament_copyright/test/test_copyright.py
+++ b/ament_copyright/test/test_copyright.py
@@ -33,3 +33,13 @@ def test_bsd_indented():
 def test_bsd_tabs():
     rc = main(argv=[os.path.join(cases_path, 'bsd_license_tabs')])
     assert rc == 0, 'Found errors'
+
+
+def test_3bsd_cpp():
+    rc = main(argv=[os.path.join(cases_path, '3clause_bsd/case2.cpp')])
+    assert rc == 0, 'Found errors'
+
+
+def test_3bsd_py():
+    rc = main(argv=[os.path.join(cases_path, '3clause_bsd/case.py')])
+    assert rc == 0, 'Found errors'


### PR DESCRIPTION
Add templates, and test cases to support 3-Clause BSD license as stated in:
[https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)

This will allow to use the 3-Clause BSD license without the confusion caused on the 'BSD2' legacy license used in Ros packages (Although it's stated as license 2.0, it is similar to the BSD-3-Clause).

This should help solving [geometry2/pull/222](https://github.com/ros2/geometry2/pull/222) and it will close #109 