### PR TITLE
Fix bug, allows using ament_copyright with bsd3

### DIFF
--- a/ament_copyright/ament_copyright/main.py
+++ b/ament_copyright/ament_copyright/main.py
@@ -218,7 +218,9 @@ def main(argv=sys.argv[1:]):
 
 def add_missing_header(file_descriptors, name, license_, verbose):
     copyright_ = 'Copyright %d %s' % (int(time.strftime('%Y')) - 1 + 1, name)
-    header = license_.file_header.format(**{'copyright': copyright_})
+    header = license_.file_header.format(**{
+        'copyright': copyright_,
+        'copyright_holder': 'the copyright holder'})
     lines = header.splitlines()
 
     if verbose:

--- a/ament_copyright/ament_copyright/main.py
+++ b/ament_copyright/ament_copyright/main.py
@@ -217,7 +217,7 @@ def main(argv=sys.argv[1:]):
 
 
 def add_missing_header(file_descriptors, name, license_, verbose):
-    copyright_ = 'Copyright %d, %s' % (int(time.strftime('%Y')) - 1 + 1, name)
+    copyright_ = 'Copyright %d %s' % (int(time.strftime('%Y')) - 1 + 1, name)
     header = license_.file_header.format(**{
         'copyright': copyright_,
         'copyright_holder': name})

--- a/ament_copyright/ament_copyright/main.py
+++ b/ament_copyright/ament_copyright/main.py
@@ -217,10 +217,10 @@ def main(argv=sys.argv[1:]):
 
 
 def add_missing_header(file_descriptors, name, license_, verbose):
-    copyright_ = 'Copyright %d %s' % (int(time.strftime('%Y')) - 1 + 1, name)
+    copyright_ = 'Copyright %d, %s' % (int(time.strftime('%Y')) - 1 + 1, name)
     header = license_.file_header.format(**{
         'copyright': copyright_,
-        'copyright_holder': 'the copyright holder'})
+        'copyright_holder': name})
     lines = header.splitlines()
 
     if verbose:


### PR DESCRIPTION
To reproduce this bug you have to use the ament_copyright tool to try adding missing headers to a file, using the bsd2 license. After sourcing the ROS workspace:

`ament_copyright --add-missing 'osrf' bsd2 src/ament/ament_lint/ament_copyright/test/cases/bsd_license/case.py`

This will cause
`KeyError: 'copyright_holder'`

Format of the bsd2 license expected a command to pass a 'copyright_holder' key as a parameter to include in the license. However, the current CLI does not includes this. This quick fix uses as copyright holder this: 'the copyright holder', so the text match the condition as expressed in: https://opensource.org/licenses/BSD-3-Clause

Later on it could be discussed if it's a desirable solution to include adding this copyright holder variable in the cli.