### PR TITLE
enable nl_func_call_start_multi_line in uncrustify

### DIFF
--- a/ament_uncrustify/ament_uncrustify/configuration/ament_code_style.cfg
+++ b/ament_uncrustify/ament_uncrustify/configuration/ament_code_style.cfg
@@ -1361,7 +1361,7 @@ nl_func_def_empty               = ignore   # ignore/add/remove/force
 nl_func_call_empty              = ignore   # ignore/add/remove/force
 
 # Whether to add newline after '(' in a function call if '(' and ')' are in different lines.
-nl_func_call_start_multi_line   = false    # false/true
+nl_func_call_start_multi_line   = true     # false/true
 
 # Whether to add newline after each ',' in a function call if '(' and ')' are in different lines.
 nl_func_call_args_multi_line    = false    # false/true


### PR DESCRIPTION
Follow up of #148.

This patch enforces that arguments not fitting in one line must start on a new line (as it is described in the ROS 2 development guide). While that requires quite a bit of existing code to be updated to be compliant the work is easily automated by calling `ament_uncrustify --reformat <path>`.

Unfortunately nobody on the original ticket was willing to update existing code to comply with the proposed change. So this PR (and the referenced ones) are doing that.

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9207)](https://ci.ros2.org/job/ci_linux/9207/)