### PR TITLE
Fix ament_clang_tidy

### DIFF
--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -14,9 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import defaultdict
 import argparse
+from collections import defaultdict
 import copy
+import json
 import multiprocessing.pool
 import os
 import re
@@ -24,11 +25,9 @@ import subprocess
 import sys
 import time
 
-from xml.sax.saxutils import escape
 from xml.sax.saxutils import quoteattr
 
 import yaml
-import json
 
 
 def main(argv=sys.argv[1:]):
@@ -56,7 +55,7 @@ def main(argv=sys.argv[1:]):
         '--jobs',
         type=int,
         default=1,
-        help="number of clang-tidy jobs to run in parallel")
+        help='number of clang-tidy jobs to run in parallel')
 
     # not using a file handle directly
     # in order to prevent leaving an empty file when something fails early
@@ -108,7 +107,7 @@ def main(argv=sys.argv[1:]):
     for file in files:
         package_dir = os.path.dirname(file)
         package_name = os.path.basename(package_dir)
-        print("linting " + package_name + "...")
+        print('linting ' + package_name + '...')
         async_outputs.append(pool.apply_async(invoke_clang_tidy, (clang_tidy_bin, file, args)))
     pool.close()
     pool.join()
@@ -226,11 +225,11 @@ def invoke_clang_tidy(clang_tidy_bin, compilation_db_path, args):
     for item in db:
         # exclude gtest sources from being checked by clang-tidy
         if is_gtest_source(os.path.basename(item['file'])):
-          continue
+            continue
         # exclude unit test sources from being checked by clang-tidy
         # because gtest macros are problematic
         if is_unittest_source(package_name, item['file']):
-          continue
+            continue
 
         full_cmd = cmd + [item['file']]
         # print(' '.join(full_cmd))

--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -158,7 +158,8 @@ def main(argv=sys.argv[1:]):
             full_cmd = cmd + [item['file']]
             # print(' '.join(full_cmd))
             try:
-                output += subprocess.check_output(full_cmd, stderr=subprocess.DEVNULL).strip().decode()
+                output += subprocess.check_output(full_cmd,
+                                                  stderr=subprocess.DEVNULL).strip().decode()
             except subprocess.CalledProcessError as e:
                 print('The invocation of "%s" failed with error code %d: %s' %
                       (os.path.basename(clang_tidy_bin), e.returncode, e),

--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -67,13 +67,6 @@ def main(argv=sys.argv[1:]):
     parser.add_argument(
         '--export-fixes',
         help='Generate a DAT file of recorded fixes')
-    # parser.add_argument(
-    #     '--fix-errors',
-    #     action='store_true',
-    #     help='Fix the suggested changes')
-    # parser.add_argument(
-    #     '--header-filter',
-    #     help='Accepts a regex and displays errors from the specified non-system headers')
     parser.add_argument(
         '--quiet',
         action='store_true',
@@ -214,8 +207,6 @@ def invoke_clang_tidy(clang_tidy_bin, compilation_db_path, args):
     if args.export_fixes:
         cmd.append('--export-fixes')
         cmd.append(args.export_fixes)
-    # if args.fix_errors:
-    #     cmd.append('--fix-errors')
     if args.quiet:
         cmd.append('--quiet')
     if args.system_headers:
@@ -254,13 +245,6 @@ def invoke_clang_tidy(clang_tidy_bin, compilation_db_path, args):
 
 def find_error_message(data):
     return data[data.rfind(':') + 2:]
-
-
-def find_line_and_col_num(data):
-    first_col = data.find(':')
-    second_col = data.find(':', first_col + 1)
-    third_col = data.find(':', second_col + 1)
-    return data[first_col + 1:second_col], data[second_col + 1:third_col]
 
 
 def get_xunit_content(report, testname, elapsed):
@@ -322,14 +306,6 @@ def get_xunit_content(report, testname, elapsed):
             xml += """  <testcase
     name=%(quoted_location)s
     classname="%(testname)s"/>
-""" % data
-
-    # output list of checked files
-    data = {
-        'escaped_files': escape(''.join(['\n* %s' % r
-                                         for r in sorted(report.keys())])),
-    }
-    xml += """  <system-out>Checked files:%(escaped_files)s</system-out>
 """ % data
 
     xml += '</testsuite>\n'

--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -89,8 +89,8 @@ def main(argv=sys.argv[1:]):
     if args.xunit_file:
         start_time = time.time()
 
-    files = get_compilation_db_files(args.paths)
-    if not files:
+    compilation_dbs = get_compilation_db_files(args.paths)
+    if not compilation_dbs:
         print('No compilation database files found', file=sys.stderr)
         return 1
 
@@ -131,8 +131,6 @@ def main(argv=sys.argv[1:]):
             cmd.append('--quiet')
         if args.system_headers:
             cmd.append('--system-headers')
-        cmd.extend(files)
-        cmd.append('--')
 
         def is_gtest_source(file_name):
             if(file_name == 'gtest_main.cc' or file_name == 'gtest-all.cc'
@@ -166,12 +164,13 @@ def main(argv=sys.argv[1:]):
                       file=sys.stderr)
         return output
 
+    files = []
     outputs = []
-    for file in files:
+    for compilation_db in compilation_dbs:
         package_dir = os.path.dirname(file)
         package_name = os.path.basename(package_dir)
         print('found compilation database for package "%s"...' % package_name)
-        output = invoke_clang_tidy(file)
+        output = invoke_clang_tidy(compilation_db)
         outputs.append(output)
 
     # output errors

--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import argparse
+from collections import defaultdict
 import copy
 import json
 import os
@@ -176,7 +177,7 @@ def main(argv=sys.argv[1:]):
         outputs.append(output)
 
     # output errors
-    report = {}
+    report = defaultdict(list)
     for filename in files:
         report[filename] = []
 

--- a/ament_clang_tidy/doc/index.rst
+++ b/ament_clang_tidy/doc/index.rst
@@ -10,22 +10,27 @@ Files with the following extensions are considered:
 How to run the check from the command line?
 -------------------------------------------
 
+*Prerequisites*: ``clang-tidy-6.0`` and ``clang-tools-6.0`` packages should
+have already been installed. ``compile_commands.json`` files should have already
+been generated (e.g.: ``colcon build --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON``).
+
 .. code:: sh
 
     ament_clang_tidy [<path> ...]
+
+If ``<path>`` is a directory, it will be recursively searched for
+"compile_commands.json" files (this is usually the ``build`` directory of a
+``colcon`` workspace). If ``<path>`` is a file, it will be treated as a
+"compile_commands.json" file.
+
+The ``--jobs`` option will control the number of clang-tidy jobs should be
+run in parallel.
 
 The ``--explain-config`` option will explain the origin of the enabled
 configuration checks.
 
 The ``--export-fixes`` option will generate a DAT file of the recorded
 fixes when supplied with a file name.
-
-When using the option ``--fix-errors`` the proposed changes are
-applied in place.
-
-The ``--header-filter`` option will accept a regex and display errors from
-the specified non-system header files.  To display errors from all non-system
-header, use ``--header-filter='.*'``.
 
 The ``--quiet`` option will suppress printing statistics about ignored
 warnings and warnings treated as errors.

--- a/ament_clang_tidy/doc/index.rst
+++ b/ament_clang_tidy/doc/index.rst
@@ -10,9 +10,9 @@ Files with the following extensions are considered:
 How to run the check from the command line?
 -------------------------------------------
 
-*Prerequisites*: ``clang-tidy-6.0`` and ``clang-tools-6.0`` packages should
-have already been installed. ``compile_commands.json`` files should have already
-been generated (e.g.: ``colcon build --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON``).
+*Prerequisites*: ``clang-tidy-6.0``, ``clang-tools-6.0``, and ``python-yaml`` packages should
+have already been installed. ``compile_commands.json`` files should have already been generated
+(e.g.: workspace built with ``colcon build --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON``).
 
 .. code:: sh
 

--- a/ament_clang_tidy/doc/index.rst
+++ b/ament_clang_tidy/doc/index.rst
@@ -29,11 +29,11 @@ configuration checks.
 The ``--export-fixes`` option will generate a DAT file of the recorded
 fixes when supplied with a file name.
 
-When using the option ``--fix-errors`` the proposed changes are 
-applied in place.   
+When using the option ``--fix-errors`` the proposed changes are
+applied in place.
 
-The ``--header-filter`` option will accept a regex and display errors from  
-the specified non-system header files.  To display errors from all non-system   
+The ``--header-filter`` option will accept a regex and display errors from
+the specified non-system header files.  To display errors from all non-system
 header, use ``--header-filter='.*'``.
 
 The ``--quiet`` option will suppress printing statistics about ignored

--- a/ament_clang_tidy/doc/index.rst
+++ b/ament_clang_tidy/doc/index.rst
@@ -23,14 +23,18 @@ If ``<path>`` is a directory, it will be recursively searched for
 ``colcon`` workspace). If ``<path>`` is a file, it will be treated as a
 "compile_commands.json" file.
 
-The ``--jobs`` option will control the number of clang-tidy jobs should be
-run in parallel.
-
 The ``--explain-config`` option will explain the origin of the enabled
 configuration checks.
 
 The ``--export-fixes`` option will generate a DAT file of the recorded
 fixes when supplied with a file name.
+
+When using the option ``--fix-errors`` the proposed changes are 
+applied in place.   
+
+The ``--header-filter`` option will accept a regex and display errors from  
+the specified non-system header files.  To display errors from all non-system   
+header, use ``--header-filter='.*'``.
 
 The ``--quiet`` option will suppress printing statistics about ignored
 warnings and warnings treated as errors.


### PR DESCRIPTION
### Changes made
- The <path> argument is now meant to point towards a compile_commands.json file or a directory that contains it, instead of source files
- Unit tests source files are currently skipped because gtest has linter violations that the ROS2 package developer wouldn't have control over

### How to use/test
Follow the README to install necessary dependencies (for example on Ubuntu 18.04, do `apt install clang-tidy-6.0 clang-tools-6.0 python-yaml`).
In a workspace that contains the packages that you want to lint (or want to test the linter on):
- Build/rebuild with `colcon build --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`
- Run `ament_clang_tidy build/`
    - Expect to see a list of linter warnings/errors printed to `stdout`
    - Prior to this fix, all of the linter errors are just complaints about missing header files
- Run `ament_clang_tidy build/ --xunit-file test.xml`
    - Expect to see a list of linter warnings/errors printed to `stdout`
    - Expect to see the same list of warnings/errors in the outputted `test.xml` file