### PR TITLE
[ament_cppcheck] Report errors from additional includes

### DIFF
--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -158,7 +158,8 @@ def main(argv=sys.argv[1:]):
         return 1
 
     # output errors
-    report = {}
+    report = defaultdict(list)
+    # even though we use a defaultdict, explicity add known files so they are listed
     for filename in files:
         report[filename] = []
     for error in root.find('errors'):
@@ -174,9 +175,6 @@ def main(argv=sys.argv[1:]):
             if os.path.samefile(key, filename):
                 filename = key
                 break
-        # report errors from additional include directories
-        if filename not in report:
-            report[filename] = []
         # in the case where relative and absolute paths are mixed for paths and
         # include_dirs cppcheck might return duplicate results
         if data not in report[filename]:

--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -174,6 +174,9 @@ def main(argv=sys.argv[1:]):
             if os.path.samefile(key, filename):
                 filename = key
                 break
+        # report errors from additional include directories
+        if filename not in report:
+            report[filename] = []
         # in the case where relative and absolute paths are mixed for paths and
         # include_dirs cppcheck might return duplicate results
         if data not in report[filename]:


### PR DESCRIPTION
Before, if an error was found in an additional include we get a KeyError exception.

---

For example: https://ci.ros2.org/job/ci_linux/9443/testReport/junit/(root)/rclcpp_action/cppcheck_xunit_missing_result/

Additional includes added to rclcpp_action and rclcpp_lifecycle in https://github.com/ros2/rclcpp/pull/1000 by chance picked up a cppcheck error in rclcpp, causing a KeyError exception.

The other option is to ignore errors from additional include directories, but I think being louder about errors is better.