### PR TITLE
Suppress internalAstError

### DIFF
--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -134,7 +134,8 @@ def main(argv=sys.argv[1:]):
            '-q',
            '-rp',
            '--xml',
-           '--xml-version=2']
+           '--xml-version=2',
+           '--suppress=internalAstError']
     if args.language:
         cmd.extend(['--language={0}'.format(args.language)])
     for include_dir in (args.include_dirs or []):


### PR DESCRIPTION
`cppcheck` can, in some cases, construct an invalid parse tree.
http://build.ros2.org/user/rotu/my-views/view/CycloneDDS/job/Fci__nightly-cyclonedds_ubuntu_focal_amd64/lastCompletedBuild/testReport/rclcpp/cppcheck/error__internalAstError__src_rclcpp_clock_cpp_159_/

```
- rclcpp.cppcheck error: internalAstError (src/rclcpp/clock.cpp:159)
  <<< failure message
    Syntax Error: AST broken, 'if' doesn't have two operands.
  >>>
```
This error sounds like a syntax error, but is in fact, not. (cppcheck doesn't seem to even find the syntax error in `if(1,1){}`)
This commit causes such errors to be silently ignored, as they are not actionable.
Signed-off-by: Dan Rose <dan@digilabs.io>
