### PR TITLE
[Dashing] Backport junit xml fixes for updated xunit plugin on ci.ros2.org

### DIFF
--- a/ament_clang_format/ament_clang_format/main.py
+++ b/ament_clang_format/ament_clang_format/main.py
@@ -303,6 +303,7 @@ def get_xunit_content(report, testname, elapsed):
 <testsuite
   name="%(testname)s"
   tests="%(test_count)d"
+  errors="0"
   failures="%(error_count)d"
   time="%(time)s"
 >

--- a/ament_clang_format/ament_clang_format/main.py
+++ b/ament_clang_format/ament_clang_format/main.py
@@ -348,8 +348,7 @@ def get_xunit_content(report, testname, elapsed):
             }
             xml += """  <testcase
     name=%(quoted_location)s
-    classname="%(testname)s"
-    status="No problems found"/>
+    classname="%(testname)s"/>
 """ % data
 
     # output list of checked files

--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -247,6 +247,7 @@ def get_xunit_content(report, testname, elapsed):
 <testsuite
   name="%(testname)s"
   tests="%(test_count)d"
+  errors="0"
   failures="%(error_count)d"
   time="%(time)s"
 >

--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -291,8 +291,7 @@ def get_xunit_content(report, testname, elapsed):
             }
             xml += """  <testcase
     name=%(quoted_location)s
-    classname="%(testname)s"
-    status="No problems found"/>
+    classname="%(testname)s"/>
 """ % data
 
     # output list of checked files

--- a/ament_copyright/ament_copyright/main.py
+++ b/ament_copyright/ament_copyright/main.py
@@ -422,6 +422,7 @@ def get_xunit_content(report, testname, elapsed):
 <testsuite
   name="%(testname)s"
   tests="%(test_count)d"
+  errors="0"
   failures="%(error_count)d"
   time="%(time)s"
 >

--- a/ament_copyright/ament_copyright/main.py
+++ b/ament_copyright/ament_copyright/main.py
@@ -449,8 +449,7 @@ def get_xunit_content(report, testname, elapsed):
             # if there is a known copyright / license report a single successful test
             xml += """  <testcase
     name=%(quoted_filename)s
-    classname="%(testname)s"
-    status="%(escaped_message)s"/>
+    classname="%(testname)s"/>
 """ % data
 
     # output list of checked files

--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -264,7 +264,6 @@ def get_xunit_content(report, testname, elapsed, skip=None):
             xml += """  <testcase
     name=%(quoted_name)s
     classname="%(testname)s"
-    status="notrun"
   >
     <skipped type="skip" message=%(quoted_message)s>
       ![CDATA[Test Skipped due to %(skip)s]]
@@ -298,8 +297,7 @@ def get_xunit_content(report, testname, elapsed, skip=None):
             }
             xml += """  <testcase
     name=%(quoted_location)s
-    classname="%(testname)s"
-    status="No problems found"/>
+    classname="%(testname)s"/>
 """ % data
 
     # output list of checked files

--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -244,9 +244,10 @@ def get_xunit_content(report, testname, elapsed, skip=None):
 <testsuite
   name="%(testname)s"
   tests="%(test_count)d"
+  errors="0"
   failures="%(error_count)d"
   time="%(time)s"
-  skip="%(skip)d"
+  skipped="%(skip)d"
 >
 """ % data
 

--- a/ament_cpplint/ament_cpplint/main.py
+++ b/ament_cpplint/ament_cpplint/main.py
@@ -281,6 +281,7 @@ def get_xunit_content(report, testname, elapsed):
   name="%(testname)s"
   tests="%(test_count)d"
   failures="%(error_count)d"
+  errors="0"
   time="%(time)s"
 >
 """ % data

--- a/ament_cpplint/ament_cpplint/main.py
+++ b/ament_cpplint/ament_cpplint/main.py
@@ -315,8 +315,7 @@ def get_xunit_content(report, testname, elapsed):
             }
             xml += """  <testcase
     name=%(quoted_location)s
-    classname="%(testname)s"
-    status="No problems found"/>
+    classname="%(testname)s"/>
 """ % data
 
     # output list of checked files

--- a/ament_flake8/ament_flake8/main.py
+++ b/ament_flake8/ament_flake8/main.py
@@ -229,8 +229,7 @@ def get_xunit_content(report, testname, elapsed):
         }
         xml += """  <testcase
     name="flake8"
-    classname="%(testname)s"
-    status="No problems found"/>
+    classname="%(testname)s"/>
 """ % data
 
     # output list of checked files

--- a/ament_flake8/ament_flake8/main.py
+++ b/ament_flake8/ament_flake8/main.py
@@ -196,6 +196,7 @@ def get_xunit_content(report, testname, elapsed):
 <testsuite
   name="%(testname)s"
   tests="%(test_count)d"
+  errors="0"
   failures="%(error_count)d"
   time="%(time)s"
 >

--- a/ament_lint_cmake/ament_lint_cmake/main.py
+++ b/ament_lint_cmake/ament_lint_cmake/main.py
@@ -193,8 +193,7 @@ def get_xunit_content(report, testname, elapsed):
             }
             xml += """  <testcase
     name=%(quoted_location)s
-    classname="%(testname)s"
-    status="No problems found"/>
+    classname="%(testname)s"/>
 """ % data
 
     # output list of checked files

--- a/ament_lint_cmake/ament_lint_cmake/main.py
+++ b/ament_lint_cmake/ament_lint_cmake/main.py
@@ -159,6 +159,7 @@ def get_xunit_content(report, testname, elapsed):
 <testsuite
   name="%(testname)s"
   tests="%(test_count)d"
+  errors="0"
   failures="%(error_count)d"
   time="%(time)s"
 >

--- a/ament_pclint/ament_pclint/main.py
+++ b/ament_pclint/ament_pclint/main.py
@@ -359,8 +359,7 @@ def get_xunit_content(report, testname, elapsed):
             }
             xml += """  <testcase
     name=%(quoted_location)s
-    classname="%(testname)s"
-    status="No problems found"/>
+    classname="%(testname)s"/>
 """ % data
 
     # output list of checked files

--- a/ament_pclint/ament_pclint/main.py
+++ b/ament_pclint/ament_pclint/main.py
@@ -323,6 +323,7 @@ def get_xunit_content(report, testname, elapsed):
 <testsuite
   name="%(testname)s"
   tests="%(test_count)d"
+  errors="0"
   failures="%(error_count)d"
   time="%(time)s"
 >

--- a/ament_pep257/ament_pep257/main.py
+++ b/ament_pep257/ament_pep257/main.py
@@ -222,8 +222,7 @@ def get_xunit_content(report, testname, elapsed):
             }
             xml += """  <testcase
     name=%(quoted_location)s
-    classname="%(testname)s"
-    status="No problems found"/>
+    classname="%(testname)s"/>
 """ % data
 
     # output list of checked files

--- a/ament_pep257/ament_pep257/main.py
+++ b/ament_pep257/ament_pep257/main.py
@@ -188,6 +188,7 @@ def get_xunit_content(report, testname, elapsed):
 <testsuite
   name="%(testname)s"
   tests="%(test_count)d"
+  errors="0"
   failures="%(error_count)d"
   time="%(time)s"
 >

--- a/ament_pep8/ament_pep8/main.py
+++ b/ament_pep8/ament_pep8/main.py
@@ -131,6 +131,7 @@ def get_xunit_content(report, testname):
 <testsuite
   name="%(testname)s"
   tests="%(test_count)d"
+  errors="0"
   failures="%(error_count)d"
   time="%(time)s"
 >

--- a/ament_pep8/ament_pep8/main.py
+++ b/ament_pep8/ament_pep8/main.py
@@ -163,8 +163,7 @@ def get_xunit_content(report, testname):
         }
         xml += """  <testcase
     name="pep8"
-    classname="%(testname)s"
-    status="No problems found"/>
+    classname="%(testname)s"/>
 """ % data
 
     # output list of checked files

--- a/ament_pyflakes/ament_pyflakes/main.py
+++ b/ament_pyflakes/ament_pyflakes/main.py
@@ -179,8 +179,7 @@ def get_xunit_content(report, testname, elapsed):
             }
             xml += """  <testcase
     name=%(quoted_location)s
-    classname="%(testname)s"
-    status="No problems found"/>
+    classname="%(testname)s"/>
 """ % data
 
     # output list of checked files

--- a/ament_pyflakes/ament_pyflakes/main.py
+++ b/ament_pyflakes/ament_pyflakes/main.py
@@ -140,6 +140,7 @@ def get_xunit_content(report, testname, elapsed):
 <testsuite
   name="%(testname)s"
   tests="%(test_count)d"
+  errors="0"
   failures="%(error_count)d"
   time="%(time)s"
 >

--- a/ament_uncrustify/ament_uncrustify/main.py
+++ b/ament_uncrustify/ament_uncrustify/main.py
@@ -356,8 +356,7 @@ def get_xunit_content(report, testname, elapsed):
             }
             xml += """  <testcase
     name=%(quoted_location)s
-    classname="%(testname)s"
-    status="No problems found"/>
+    classname="%(testname)s"/>
 """ % data
 
     # output list of checked files

--- a/ament_uncrustify/ament_uncrustify/main.py
+++ b/ament_uncrustify/ament_uncrustify/main.py
@@ -323,6 +323,7 @@ def get_xunit_content(report, testname, elapsed):
   name="%(testname)s"
   tests="%(test_count)d"
   failures="%(error_count)d"
+  errors="0"
   time="%(time)s"
 >
 """ % data

--- a/ament_xmllint/ament_xmllint/main.py
+++ b/ament_xmllint/ament_xmllint/main.py
@@ -252,8 +252,7 @@ def get_xunit_content(report, testname, elapsed):
             }
             xml += """  <testcase
     name=%(quoted_location)s
-    classname="%(testname)s"
-    status="No problems found"/>
+    classname="%(testname)s"/>
 """ % data
 
     # output list of checked files

--- a/ament_xmllint/ament_xmllint/main.py
+++ b/ament_xmllint/ament_xmllint/main.py
@@ -218,6 +218,7 @@ def get_xunit_content(report, testname, elapsed):
 <testsuite
   name="%(testname)s"
   tests="%(test_count)d"
+  errors="0"
   failures="%(error_count)d"
   time="%(time)s"
 >


### PR DESCRIPTION
This PR along with its companion ament/ament_cmake#230 should fix Dashing CI builds failing during the test result parsing stage on ci.ros2.org.

Backports PRs #212 and #220.