### PR TITLE
some more clang format options

### DIFF
--- a/ament_clang_format/ament_clang_format/configuration/.clang-format
+++ b/ament_clang_format/ament_clang_format/configuration/.clang-format
@@ -16,4 +16,15 @@ ContinuationIndentWidth: 2
 DerivePointerAlignment: false
 PointerAlignment: Middle
 ReflowComments: false
+SpaceBeforeCtorInitializerColon: true
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: AfterColon
+BreakConstructorInitializersBeforeComma: true
+BreakConstructorInitializers: BeforeColon
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+FixNamespaceComments: true
+IncludeBlocks: Regroup
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpacesBeforeTrailingComments: 2
 ...


### PR DESCRIPTION
a few changes in how constructor initializer lists are formatted, 2 spaces before trailing comment, sorting `#includes` and auto completion for `namespace` ending.

Signed-off-by: Karsten Knese <karsten@openrobotics.org>