### PR TITLE
Increase timeout for cppcheck runs.

### DIFF
--- a/ament_cmake_cppcheck/cmake/ament_cppcheck.cmake
+++ b/ament_cmake_cppcheck/cmake/ament_cppcheck.cmake
@@ -55,7 +55,7 @@ function(ament_cppcheck)
   ament_add_test(
     "${ARG_TESTNAME}"
     COMMAND ${cmd}
-    TIMEOUT 120
+    TIMEOUT 180
     OUTPUT_FILE "${CMAKE_BINARY_DIR}/ament_cppcheck/${ARG_TESTNAME}.txt"
     RESULT_FILE "${result_file}"
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"


### PR DESCRIPTION
On some platforms the cppcheck for the test_rclcpp package is hitting
the timeout. Bumping the timeout on those platforms shows that the build
takes about 130 seconds. So 180 should be sufficient room to grow
without raising it too high.
