### PR TITLE
Allow AMENT_IGNORE markers to be directories

### DIFF
--- a/ament_clang_format/ament_clang_format/main.py
+++ b/ament_clang_format/ament_clang_format/main.py
@@ -253,7 +253,7 @@ def get_files(paths, extensions):
     for path in paths:
         if os.path.isdir(path):
             for dirpath, dirnames, filenames in os.walk(path):
-                if 'AMENT_IGNORE' in filenames:
+                if 'AMENT_IGNORE' in dirnames + filenames:
                     dirnames[:] = []
                     continue
                 # ignore folder starting with . or _

--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -243,7 +243,7 @@ def get_compilation_db_files(paths):
     for path in paths:
         if os.path.isdir(path):
             for dirpath, dirnames, filenames in os.walk(path):
-                if 'AMENT_IGNORE' in filenames:
+                if 'AMENT_IGNORE' in dirnames + filenames:
                     dirnames[:] = []
                     continue
                 # ignore folder starting with . or _

--- a/ament_copyright/ament_copyright/crawler.py
+++ b/ament_copyright/ament_copyright/crawler.py
@@ -25,7 +25,7 @@ def get_files(paths, extensions, skip_package_level_setup_py=True):
             if is_repository_root(path):
                 add_files_for_all_filetypes(path, files)
             for dirpath, dirnames, filenames in os.walk(path):
-                if 'AMENT_IGNORE' in filenames:
+                if 'AMENT_IGNORE' in dirnames + filenames:
                     dirnames[:] = []
                     continue
                 if is_repository_root(dirpath):

--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -215,7 +215,7 @@ def get_files(paths, extensions):
     for path in paths:
         if os.path.isdir(path):
             for dirpath, dirnames, filenames in os.walk(path):
-                if 'AMENT_IGNORE' in filenames:
+                if 'AMENT_IGNORE' in dirnames + filenames:
                     dirnames[:] = []
                     continue
                 # ignore folder starting with . or _

--- a/ament_cpplint/ament_cpplint/main.py
+++ b/ament_cpplint/ament_cpplint/main.py
@@ -205,7 +205,7 @@ def get_file_groups(paths, extensions):
     for path in paths:
         if os.path.isdir(path):
             for dirpath, dirnames, filenames in os.walk(path):
-                if 'AMENT_IGNORE' in filenames:
+                if 'AMENT_IGNORE' in dirnames + filenames:
                     dirnames[:] = []
                     continue
                 # ignore folder starting with . or _

--- a/ament_flake8/ament_flake8/main.py
+++ b/ament_flake8/ament_flake8/main.py
@@ -79,7 +79,7 @@ def main_with_errors(argv=sys.argv[1:]):
     if args.excludes is None:
         args.excludes = []
     for dirpath, dirnames, filenames in os.walk(os.getcwd()):
-        if 'AMENT_IGNORE' in filenames:
+        if 'AMENT_IGNORE' in dirnames + filenames:
             dirnames[:] = []
             args.excludes.append(dirpath)
 

--- a/ament_lint_cmake/ament_lint_cmake/main.py
+++ b/ament_lint_cmake/ament_lint_cmake/main.py
@@ -125,7 +125,7 @@ def get_files(paths):
     for path in paths:
         if os.path.isdir(path):
             for dirpath, dirnames, filenames in os.walk(path):
-                if 'AMENT_IGNORE' in filenames:
+                if 'AMENT_IGNORE' in dirnames + filenames:
                     dirnames[:] = []
                     continue
                 # ignore folder starting with . or _

--- a/ament_mypy/ament_mypy/main.py
+++ b/ament_mypy/ament_mypy/main.py
@@ -215,7 +215,7 @@ def _get_files(paths: List[str]) -> List[str]:
     for path in paths:
         if os.path.isdir(path):
             for dirpath, dirnames, filenames in os.walk(path):
-                if 'AMENT_IGNORE' in filenames:
+                if 'AMENT_IGNORE' in dirnames + filenames:
                     dirnames[:] = []
                     continue
                 # ignore folder starting with . or _

--- a/ament_pclint/ament_pclint/main.py
+++ b/ament_pclint/ament_pclint/main.py
@@ -293,7 +293,7 @@ def get_files(paths, extensions):
     for path in paths:
         if os.path.isdir(path):
             for dirpath, dirnames, filenames in os.walk(path):
-                if 'AMENT_IGNORE' in filenames:
+                if 'AMENT_IGNORE' in dirnames + filenames:
                     dirnames[:] = []
                     continue
                 # ignore folder starting with . or _

--- a/ament_pyflakes/ament_pyflakes/main.py
+++ b/ament_pyflakes/ament_pyflakes/main.py
@@ -111,7 +111,7 @@ def get_files(paths):
     for path in paths:
         if os.path.isdir(path):
             for dirpath, dirnames, filenames in os.walk(path):
-                if 'AMENT_IGNORE' in filenames:
+                if 'AMENT_IGNORE' in dirnames + filenames:
                     dirnames[:] = []
                     continue
                 # ignore folder starting with . or _

--- a/ament_uncrustify/ament_uncrustify/main.py
+++ b/ament_uncrustify/ament_uncrustify/main.py
@@ -219,7 +219,7 @@ def get_files(paths, extension_types, excludes=[], language=None):
     for path in paths:
         if os.path.isdir(path):
             for dirpath, dirnames, filenames in os.walk(path):
-                if 'AMENT_IGNORE' in filenames:
+                if 'AMENT_IGNORE' in dirnames + filenames:
                     dirnames[:] = []
                     continue
                 # ignore folder starting with . or _

--- a/ament_xmllint/ament_xmllint/main.py
+++ b/ament_xmllint/ament_xmllint/main.py
@@ -157,7 +157,7 @@ def get_files(paths, extensions, excludes=[]):
     for path in paths:
         if os.path.isdir(path):
             for dirpath, dirnames, filenames in os.walk(path):
-                if 'AMENT_IGNORE' in filenames:
+                if 'AMENT_IGNORE' in dirnames + filenames:
                     dirnames[:] = []
                     continue
                 # ignore folder starting with . or _


### PR DESCRIPTION
This matches `COLCON_IGNORE`, which checks that a file *exists*, not necessarily that it is a normal file.

Signed-off-by: Dan Rose <dan@digilabs.io>
