### PR TITLE
Allow to configure language in cppcheck with a global var

### DIFF
--- a/ament_cmake_cppcheck/cmake/ament_cmake_cppcheck_lint_hook.cmake
+++ b/ament_cmake_cppcheck/cmake/ament_cmake_cppcheck_lint_hook.cmake
@@ -35,8 +35,8 @@ if(_source_files)
 
   # Language
   set(_language "")
-  if(DEFINED ament_cmake_cppcheck_ADDITIONAL_LANGUAGE)
-    set(_language ${ament_cmake_cppcheck_ADDITIONAL_LANGUAGE})
+  if(DEFINED ament_cmake_cppcheck_LANGUAGE)
+    set(_language ${ament_cmake_cppcheck_LANGUAGE})
   endif()
 
   # BUILDSYSTEM_TARGETS only supported in CMake >= 3.7

--- a/ament_cmake_cppcheck/cmake/ament_cmake_cppcheck_lint_hook.cmake
+++ b/ament_cmake_cppcheck/cmake/ament_cmake_cppcheck_lint_hook.cmake
@@ -36,7 +36,7 @@ if(_source_files)
   # Language
   set(_language "")
   if(DEFINED ament_cmake_cppcheck_ADDITIONAL_LANGUAGE)
-    list(APPEND _language ${ament_cmake_cppcheck_ADDITIONAL_LANGUAGE})
+    set(_language ${ament_cmake_cppcheck_ADDITIONAL_LANGUAGE})
   endif()
 
   # BUILDSYSTEM_TARGETS only supported in CMake >= 3.7

--- a/ament_cmake_cppcheck/cmake/ament_cmake_cppcheck_lint_hook.cmake
+++ b/ament_cmake_cppcheck/cmake/ament_cmake_cppcheck_lint_hook.cmake
@@ -37,6 +37,7 @@ if(_source_files)
   set(_language "")
   if(DEFINED ament_cmake_cppcheck_LANGUAGE)
     set(_language LANGUAGE ${ament_cmake_cppcheck_LANGUAGE})
+    message(STATUS "Configured cppcheck language : ${_language}")
   endif()
 
   # Get exclude paths for added targets
@@ -76,7 +77,6 @@ if(_source_files)
   endif()
 
   message(STATUS "Configured cppcheck include dirs: ${_all_include_dirs}")
-  message(STATUS "Configured cppcheck language : ${_language}")
   message(
     STATUS "Configured cppcheck exclude dirs and/or files: ${_all_exclude}"
   )

--- a/ament_cmake_cppcheck/cmake/ament_cmake_cppcheck_lint_hook.cmake
+++ b/ament_cmake_cppcheck/cmake/ament_cmake_cppcheck_lint_hook.cmake
@@ -33,7 +33,7 @@ if(_source_files)
     list(APPEND _all_include_dirs ${ament_cmake_cppcheck_ADDITIONAL_INCLUDE_DIRS})
   endif()
 
-  # Language
+  # Forces cppcheck to consider ament_cmake_cppcheck_LANGUAGE as the given language if defined
   set(_language "")
   if(DEFINED ament_cmake_cppcheck_LANGUAGE)
     set(_language LANGUAGE ${ament_cmake_cppcheck_LANGUAGE})

--- a/ament_cmake_cppcheck/cmake/ament_cmake_cppcheck_lint_hook.cmake
+++ b/ament_cmake_cppcheck/cmake/ament_cmake_cppcheck_lint_hook.cmake
@@ -34,7 +34,7 @@ if(_source_files)
   endif()
 
   # Language
-  set(_language "")
+  set(_language "c")
   if(DEFINED ament_cmake_cppcheck_LANGUAGE)
     set(_language ${ament_cmake_cppcheck_LANGUAGE})
   endif()

--- a/ament_cmake_cppcheck/cmake/ament_cmake_cppcheck_lint_hook.cmake
+++ b/ament_cmake_cppcheck/cmake/ament_cmake_cppcheck_lint_hook.cmake
@@ -80,5 +80,7 @@ if(_source_files)
   message(
     STATUS "Configured cppcheck exclude dirs and/or files: ${_all_exclude}"
   )
-  ament_cppcheck(${_language} INCLUDE_DIRS ${_all_include_dirs} EXCLUDE ${_all_exclude})
+  ament_cppcheck(
+    ${_language} INCLUDE_DIRS ${_all_include_dirs} EXCLUDE ${_all_exclude}
+  )
 endif()

--- a/ament_cmake_cppcheck/cmake/ament_cmake_cppcheck_lint_hook.cmake
+++ b/ament_cmake_cppcheck/cmake/ament_cmake_cppcheck_lint_hook.cmake
@@ -34,9 +34,9 @@ if(_source_files)
   endif()
 
   # Language
-  set(_language "c")
+  set(_language "")
   if(DEFINED ament_cmake_cppcheck_LANGUAGE)
-    set(_language ${ament_cmake_cppcheck_LANGUAGE})
+    set(_language LANGUAGE ${ament_cmake_cppcheck_LANGUAGE})
   endif()
 
   # BUILDSYSTEM_TARGETS only supported in CMake >= 3.7
@@ -71,5 +71,5 @@ if(_source_files)
 
   message(STATUS "Configured cppcheck include dirs: ${_all_include_dirs}")
   message(STATUS "Configured cppcheck language : ${_language}")
-  ament_cppcheck(LANGUAGE ${_language} INCLUDE_DIRS ${_all_include_dirs})
+  ament_cppcheck(${_language} INCLUDE_DIRS ${_all_include_dirs})
 endif()

--- a/ament_cmake_cppcheck/cmake/ament_cmake_cppcheck_lint_hook.cmake
+++ b/ament_cmake_cppcheck/cmake/ament_cmake_cppcheck_lint_hook.cmake
@@ -37,7 +37,7 @@ if(_source_files)
   set(_language "")
   if(DEFINED ament_cmake_cppcheck_LANGUAGE)
     set(_language LANGUAGE ${ament_cmake_cppcheck_LANGUAGE})
-    message(STATUS "Configured cppcheck language : ${_language}")
+    message(STATUS "Configured cppcheck language: ${ament_cmake_cppcheck_LANGUAGE}")
   endif()
 
   # Get exclude paths for added targets

--- a/ament_cmake_cppcheck/cmake/ament_cmake_cppcheck_lint_hook.cmake
+++ b/ament_cmake_cppcheck/cmake/ament_cmake_cppcheck_lint_hook.cmake
@@ -33,6 +33,12 @@ if(_source_files)
     list(APPEND _all_include_dirs ${ament_cmake_cppcheck_ADDITIONAL_INCLUDE_DIRS})
   endif()
 
+  # Language
+  set(_language "")
+  if(DEFINED ament_cmake_cppcheck_ADDITIONAL_LANGUAGE)
+    list(APPEND _language ${ament_cmake_cppcheck_ADDITIONAL_LANGUAGE})
+  endif()
+
   # BUILDSYSTEM_TARGETS only supported in CMake >= 3.7
   if(NOT CMAKE_VERSION VERSION_LESS "3.7.0")
     get_directory_property(_build_targets DIRECTORY ${PROJECT_SOURCE_DIR} BUILDSYSTEM_TARGETS)
@@ -64,5 +70,6 @@ if(_source_files)
   endif()
 
   message(STATUS "Configured cppcheck include dirs: ${_all_include_dirs}")
-  ament_cppcheck(INCLUDE_DIRS ${_all_include_dirs})
+  message(STATUS "Configured cppcheck language : ${_language}")
+  ament_cppcheck(LANGUAGE ${_language} INCLUDE_DIRS ${_all_include_dirs})
 endif()


### PR DESCRIPTION
Allow to configure language in cppcheck with a global var

Signed-off-by: ahcorde <ahcorde@gmail.com>