### PR TITLE
Expand ignores to pep257 definition.

### DIFF
--- a/ament_pep257/ament_pep257/main.py
+++ b/ament_pep257/ament_pep257/main.py
@@ -38,6 +38,10 @@ except ImportError:  # try version 1.0.0
 log.setLevel(logging.INFO)
 
 
+_conventions = set(pydocstyle.conventions.keys())
+_conventions.add('ament')
+
+
 def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(
         description='Check docstrings against the style conventions in PEP 257.',
@@ -58,9 +62,9 @@ def main(argv=sys.argv[1:]):
     )
     err_code_group.add_argument(
         '--convention',
-        choices=pydocstyle.conventions,
+        choices=_conventions,
         default='ament',
-        help=f'Choose a preset list of error codes. Valid options are {pydocstyle.conventions}'
+        help=f'Choose a preset list of error codes. Valid options are {_conventions}'
     )
     parser.add_argument(
         '--add-ignore',

--- a/ament_pep257/ament_pep257/main.py
+++ b/ament_pep257/ament_pep257/main.py
@@ -41,6 +41,20 @@ log.setLevel(logging.INFO)
 _conventions = set(pydocstyle.conventions.keys())
 _conventions.add('ament')
 
+_ament_ignore = [
+    'D100',
+    'D101',
+    'D102',
+    'D103',
+    'D104',
+    'D105',
+    'D106',
+    'D107',
+    'D203',
+    'D212',
+    'D404',
+]
+
 
 def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(
@@ -64,7 +78,10 @@ def main(argv=sys.argv[1:]):
         '--convention',
         choices=_conventions,
         default='ament',
-        help=f'Choose a preset list of error codes. Valid options are {_conventions}'
+        help=(
+            f'Choose a preset list of error codes. Valid options are {_conventions}.'
+            f'The "ament" convention is defined as --ignore {_ament_ignore}.'
+        ),
     )
     parser.add_argument(
         '--add-ignore',
@@ -107,21 +124,7 @@ def main(argv=sys.argv[1:]):
     args.add_select = ','.join(args.add_select)
     args.add_ignore = ','.join(args.add_ignore)
     if not (args.ignore or args.select) and args.convention == 'ament':
-        args.ignore = ','.join(
-            [
-                'D100',
-                'D101',
-                'D102',
-                'D103',
-                'D104',
-                'D105',
-                'D106',
-                'D107',
-                'D203',
-                'D212',
-                'D404',
-            ]
-        )
+        args.ignore = ','.join(_ament_ignore)
 
     excludes = [os.path.abspath(e) for e in args.excludes]
     report = generate_pep257_report(args.paths, excludes, args.ignore, args.select,

--- a/ament_pep257/ament_pep257/main.py
+++ b/ament_pep257/ament_pep257/main.py
@@ -107,17 +107,21 @@ def main(argv=sys.argv[1:]):
     args.add_select = ','.join(args.add_select)
     args.add_ignore = ','.join(args.add_ignore)
     if not (args.ignore or args.select) and args.convention == 'ament':
-        args.ignore = ','.join(['D100',
-                                'D101',
-                                'D102',
-                                'D103',
-                                'D104',
-                                'D105',
-                                'D106',
-                                'D107',
-                                'D203',
-                                'D212',
-                                'D404'])
+        args.ignore = ','.join(
+            [
+                'D100',
+                'D101',
+                'D102',
+                'D103',
+                'D104',
+                'D105',
+                'D106',
+                'D107',
+                'D203',
+                'D212',
+                'D404',
+            ]
+        )
 
     excludes = [os.path.abspath(e) for e in args.excludes]
     report = generate_pep257_report(args.paths, excludes, args.ignore, args.select,

--- a/ament_pep257/ament_pep257/main.py
+++ b/ament_pep257/ament_pep257/main.py
@@ -45,11 +45,14 @@ def main(argv=sys.argv[1:]):
     parser.add_argument(
         '--ignore',
         nargs='*',
-        default=[
-            'D100', 'D101', 'D102', 'D103', 'D104', 'D105', 'D106', 'D107',
-            'D203', 'D212', 'D404',
-        ],
+        default=['D1'],
         help='The pep257 categories to ignore')
+    parser.add_argument(
+        '--select',
+        nargs='*',
+        default=[],
+        help='The additional pydocstyle checks to run'
+    )
     parser.add_argument(
         'paths',
         nargs='*',
@@ -74,7 +77,7 @@ def main(argv=sys.argv[1:]):
         start_time = time.time()
 
     excludes = [os.path.abspath(e) for e in args.excludes]
-    report = generate_pep257_report(args.paths, excludes, args.ignore)
+    report = generate_pep257_report(args.paths, excludes, args.ignore, args.select)
     error_count = sum(len(r[1]) for r in report)
 
     # print summary
@@ -112,12 +115,15 @@ def _filename_in_excludes(filename, excludes):
     return any(os.path.commonpath([absname, e]) == e for e in excludes)
 
 
-def generate_pep257_report(paths, excludes, ignore):
+def generate_pep257_report(paths, excludes, ignore, selected):
     conf = ConfigurationParser()
     sys_argv = sys.argv
     sys.argv = [
         'main',
-        '--ignore=' + ','.join(ignore),
+        '--add-ignore=' + ','.join(ignore),
+        '--add-select=' + ','.join(selected),
+        '--match', r'.*\.py',
+        '--match-dir', r'[^\._].*',
     ]
     sys.argv += paths
     conf.parse()

--- a/ament_pep257/ament_pep257/main.py
+++ b/ament_pep257/ament_pep257/main.py
@@ -46,11 +46,13 @@ def main(argv=sys.argv[1:]):
         '--ignore',
         nargs='+',
         action='extend',
+        default=[],
         help='The pep257 error codes to ignore. Has precedence over --select.')
     parser.add_argument(
         '--select',
         nargs='+',
         action='extend',
+        default=[],
         help='The pep257 error codes to check.'
     )
     parser.add_argument(

--- a/ament_pep257/ament_pep257/main.py
+++ b/ament_pep257/ament_pep257/main.py
@@ -20,6 +20,7 @@ import logging
 import os
 import sys
 import time
+import warnings
 from xml.sax.saxutils import escape
 from xml.sax.saxutils import quoteattr
 
@@ -45,13 +46,19 @@ def main(argv=sys.argv[1:]):
     parser.add_argument(
         '--ignore',
         nargs='*',
-        default=['D1'],
-        help='The pep257 categories to ignore')
+        default=[],
+        help='The pep257 error codes to ignore.')
     parser.add_argument(
         '--select',
         nargs='*',
         default=[],
-        help='The additional pydocstyle checks to run'
+        help='The pep257 error codes to check.'
+    )
+    parser.add_argument(
+        '--allow-undocumented',
+        type=bool,
+        default=None,
+        help='Ignore D1 pep257 error codes, allowing undocumented code'
     )
     parser.add_argument(
         'paths',
@@ -75,6 +82,12 @@ def main(argv=sys.argv[1:]):
 
     if args.xunit_file:
         start_time = time.time()
+    if args.allow_undocumented:
+        args.ignore.append('D1')
+    elif args.allow_undocumented is None:
+        warnings.warn('Argument "--allow-undocumented" will be required in a future version. '
+                      'Defaulting to --allow-undocumented=True')
+        args.ignore.append('D1')
 
     excludes = [os.path.abspath(e) for e in args.excludes]
     report = generate_pep257_report(args.paths, excludes, args.ignore, args.select)

--- a/ament_pep257/ament_pep257/main.py
+++ b/ament_pep257/ament_pep257/main.py
@@ -174,9 +174,9 @@ def generate_pep257_report(paths, excludes, ignore, select, convention, add_igno
     else:
         sys.argv += ['--convention', convention]
     if add_ignore:
-        sys_argv += ['--add-ignore', add_ignore]
+        sys.argv += ['--add-ignore', add_ignore]
     if add_select:
-        sys_argv += ['--add-select', add_select]
+        sys.argv += ['--add-select', add_select]
     sys.argv += paths
     conf.parse()
     sys.argv = sys_argv


### PR DESCRIPTION
Fixes #240 by using `--add-ignore` to allow user to expand pep257 ignores, and add error codes to check.

`-add-select` functionality added via the `--select` flag, allowing full customization of error codes to check

Signed-off-by: Ted Kern <ted.kern@canonical.com>