### PR TITLE
Remove match args to allow pydocstyle defaults

### DIFF
--- a/ament_pep257/ament_pep257/main.py
+++ b/ament_pep257/ament_pep257/main.py
@@ -118,8 +118,6 @@ def generate_pep257_report(paths, excludes, ignore):
     sys.argv = [
         'main',
         '--ignore=' + ','.join(ignore),
-        '--match', r'.*\.py',
-        '--match-dir', r'[^\._].*',
     ]
     sys.argv += paths
     conf.parse()


### PR DESCRIPTION
Changes `--match` to use pydocstyle default

- Current: `.*\.py`
- New (Default): `(?!test_).*\.py`
Result: don't check 'test_*' files for documentation

Changes `--match-dir` to use pydocstyle default

- Current: `[^\._].*`
- New (Default): `[^\.].*`
Result: include private ('_*') package directories in checks

Signed-off-by: Ted Kern <ted.kern@canonical.com>