### PR TITLE
Remove check of source files done in lint hook

### DIFF
--- a/ament_cmake_copyright/cmake/ament_cmake_copyright_lint_hook.cmake
+++ b/ament_cmake_copyright/cmake/ament_cmake_copyright_lint_hook.cmake
@@ -12,21 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-file(GLOB_RECURSE _source_files FOLLOW_SYMLINKS
-  "*.cmake"
-
-  "*.c"
-  "*.cc"
-  "*.cpp"
-  "*.cxx"
-  "*.h"
-  "*.hh"
-  "*.hpp"
-  "*.hxx"
-
-  "*.py"
-)
-if(_source_files)
-  message(STATUS "Added test 'copyright' to check for copyright in CMake / C / C++ / Python code")
-  ament_copyright()
-endif()
+message(STATUS "Added test 'copyright' to check for copyright in source files and LICENSE status")
+ament_copyright()

--- a/ament_cmake_copyright/cmake/ament_cmake_copyright_lint_hook.cmake
+++ b/ament_cmake_copyright/cmake/ament_cmake_copyright_lint_hook.cmake
@@ -12,5 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-message(STATUS "Added test 'copyright' to check for copyright in source files and LICENSE status")
+message(
+  STATUS
+  "Added test 'copyright' to check source files copyright and LICENSE")
 ament_copyright()


### PR DESCRIPTION
As the title says, this will close #237. The comment was reworded as well to "source files" as this distinction is made on the `ament_copyright` linter.

 
Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>