### PR TITLE
Remove output on stderr for case that is not an error

### DIFF
--- a/ament_copyright/ament_copyright/main.py
+++ b/ament_copyright/ament_copyright/main.py
@@ -112,7 +112,6 @@ def main(argv=sys.argv[1:]):
         filenames = [f for f in filenames if os.path.basename(f) not in args.excludes]
     if not filenames:
         print('No repository roots and files found')
-        return 0
 
     file_descriptors = {}
     for filename in sorted(filenames):

--- a/ament_copyright/ament_copyright/main.py
+++ b/ament_copyright/ament_copyright/main.py
@@ -111,7 +111,7 @@ def main(argv=sys.argv[1:]):
     if args.excludes:
         filenames = [f for f in filenames if os.path.basename(f) not in args.excludes]
     if not filenames:
-        print('No repository roots and files found', file=sys.stderr)
+        print('No repository roots and files found')
         return 0
 
     file_descriptors = {}


### PR DESCRIPTION
This PR solves copyright test fails caused by #247. For the case of not a main repo file, the `ament_copyright` linter returned "no error" but printed info on `stderr` and didn't generate a result xml file. 

Failing nightly CI before the fix:
* https://ci.ros2.org/view/nightly/job/nightly_linux_release/1546

CI with packages that were reporting copyright errors before this fix:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10803)](http://ci.ros2.org/job/ci_linux/10803/)

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>