### PR TITLE
Close source files after reading them

### DIFF
--- a/ament_cpplint/ament_cpplint/cpplint.py
+++ b/ament_cpplint/ament_cpplint/cpplint.py
@@ -6031,7 +6031,8 @@ def ProcessFile(filename, vlevel, extra_check_functions=[]):
                                         codecs.getwriter('utf8'),
                                         'replace').read().split('\n')
     else:
-      lines = codecs.open(filename, 'r', 'utf8', 'replace').read().split('\n')
+      with codecs.open(filename, 'r', 'utf8', 'replace') as f:
+          lines = f.read().split('\n')
 
     # Remove trailing '\r'.
     # The -1 accounts for the extra trailing blank line we get from split()

--- a/ament_cpplint/ament_cpplint/cpplint.py
+++ b/ament_cpplint/ament_cpplint/cpplint.py
@@ -6031,8 +6031,8 @@ def ProcessFile(filename, vlevel, extra_check_functions=[]):
                                         codecs.getwriter('utf8'),
                                         'replace').read().split('\n')
     else:
-      with codecs.open(filename, 'r', 'utf8', 'replace') as f:
-          lines = f.read().split('\n')
+      with codecs.open(filename, 'r', 'utf8', 'replace') as target_file:
+          lines = target_file.read().split('\n')
 
     # Remove trailing '\r'.
     # The -1 accounts for the extra trailing blank line we get from split()

--- a/ament_lint_cmake/ament_lint_cmake/cmakelint.py
+++ b/ament_lint_cmake/ament_lint_cmake/cmakelint.py
@@ -405,20 +405,21 @@ def _ProcessFile(filename):
         return
     global _package_state
     _package_state = _CMakePackageState()
-    for l in open(filename).readlines():
-        l = l.rstrip('\n')
-        if l.endswith('\r'):
-            have_cr = True
-            l = l.rstrip('\r')
-        lines.append(l)
-        # Check this line to see if it is a lint_cmake pragma
-        if l.startswith(linter_pragma_start):
-            try:
-                _lint_state.SetFilters(l[len(linter_pragma_start):])
-            except:
-                print("Exception occurred while processing '{0}:{1}':"
-                      .format(filename, len(lines)))
-                raise
+    with open(filename) as f:
+        for l in f.readlines():
+            l = l.rstrip('\n')
+            if l.endswith('\r'):
+                have_cr = True
+                l = l.rstrip('\r')
+            lines.append(l)
+            # Check this line to see if it is a lint_cmake pragma
+            if l.startswith(linter_pragma_start):
+                try:
+                    _lint_state.SetFilters(l[len(linter_pragma_start):])
+                except:
+                    print("Exception occurred while processing '{0}:{1}':"
+                          .format(filename, len(lines)))
+                    raise
     lines.append('# Lines end here')
     # Check file name after reading lines incase of a # lint_cmake: pragma
     CheckFileName(filename, Error)


### PR DESCRIPTION
Resolves the ResourceWarning messages coming to the console during testing with debug-enabled Python. These messages cause a significant amount of noise on the console.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10813)](http://ci.ros2.org/job/ci_linux/10813/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6191)](http://ci.ros2.org/job/ci_linux-aarch64/6191/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8804)](http://ci.ros2.org/job/ci_osx/8804/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10699)](http://ci.ros2.org/job/ci_windows/10699/)

Example warning:
```
C:\ci\ws\install\Lib\site-packages\ament_lint_cmake\cmakelint.py:408: ResourceWarning: unclosed file <_io.TextIOWrapper name='CMakeLists.txt' mode='r' encoding='cp1252'>
  for l in open(filename).readlines():
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```