### PR TITLE
[Eloquent] Fix bug, allows using ament_copyright with bsd3 (#206)

### DIFF
--- a/ament_copyright/ament_copyright/main.py
+++ b/ament_copyright/ament_copyright/main.py
@@ -218,7 +218,9 @@ def main(argv=sys.argv[1:]):
 
 def add_missing_header(file_descriptors, name, license_, verbose):
     copyright_ = 'Copyright %d %s' % (int(time.strftime('%Y')) - 1 + 1, name)
-    header = license_.file_header.format(**{'copyright': copyright_})
+    header = license_.file_header.format(**{
+        'copyright': copyright_,
+        'copyright_holder': name})
     lines = header.splitlines()
 
     if verbose:


### PR DESCRIPTION
Eloquent Backport of #206 

Fix bug, allows using ament_copyright with bsd3

In the bs2 headers, exists a "{copyright_holder}" text that causes a problem
when using the command ament_copyright to add headers to a source file.

This fix adds a default value for that key, to match the original 3-Clause BSD
text, and allowing to use the tool.

Signed-off-by: Jorge J. Perez <jjperez@ekumenlabs.com>