### PR TITLE
Remove use of pkg_resources from ament_lint.

### DIFF
--- a/ament_copyright/ament_copyright/__init__.py
+++ b/ament_copyright/ament_copyright/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pkg_resources
+import importlib_metadata
 
 
 COPYRIGHT_GROUP = 'ament_copyright.copyright_name'
@@ -35,8 +35,7 @@ UNKNOWN_IDENTIFIER = '<unknown>'
 
 def get_copyright_names():
     names = {}
-    for entry_point in pkg_resources.iter_entry_points(
-            group=COPYRIGHT_GROUP):
+    for entry_point in importlib_metadata.entry_points().get(COPYRIGHT_GROUP, []):
         assert entry_point.name != UNKNOWN_IDENTIFIER, \
             "Invalid entry point name '%s'" % entry_point.name
         name = entry_point.load()
@@ -46,8 +45,7 @@ def get_copyright_names():
 
 def get_licenses():
     licenses = {}
-    for entry_point in pkg_resources.iter_entry_points(
-            group=LICENSE_GROUP):
+    for entry_point in importlib_metadata.entry_points().get(LICENSE_GROUP, []):
         assert entry_point.name != UNKNOWN_IDENTIFIER, \
             "Invalid entry point name '%s'" % entry_point.name
         licenses[entry_point.name] = entry_point.load()

--- a/ament_copyright/package.xml
+++ b/ament_copyright/package.xml
@@ -11,6 +11,7 @@
   <license>Apache License 2.0</license>
 
   <exec_depend>ament_lint</exec_depend>
+  <exec_depend>python3-importlib-metadata</exec_depend>
 
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>


### PR DESCRIPTION
Replace it with the use of the more modern importlib_metadata
library.  There are a couple of reasons to do this:

1.  pkg_resources is quite slow to import; on my machine,
just firing up the python interpreter takes ~35ms, while
firing up the python interpreter and importing pkg_resources
takes ~175ms.  Firing up the python interpreter and importing
importlib_metadata takes ~70ms.  Removing 100ms per invocation
of the command-line both makes it speedier for users, and
will speed up our tests (which call out to the command-line
quite a lot).

2.  pkg_resources is somewhat deprecated and being replaced
by importlib.  https://importlib-metadata.readthedocs.io/en/latest/using.html
describes some of it

Note: By itself, this change is not enough to completely remove our
dependence on pkg_resources.  We'll also have to do something about
the console_scripts that setup.py generates.  That will be
a separate effort.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

See ros2/ros2#919 for more details on why we want to do this.