### PR TITLE
increase default timeout for CMake copyright linter to 120s

### DIFF
--- a/ament_cmake_copyright/cmake/ament_copyright.cmake
+++ b/ament_cmake_copyright/cmake/ament_copyright.cmake
@@ -17,15 +17,20 @@
 #
 # :param TESTNAME: the name of the test, default: "copyright"
 # :type TESTNAME: string
+# :param TIMEOUT: the test timeout in seconds, default: 120
+# :type TIMEOUT: integer
 # :param ARGN: the files or directories to check
 # :type ARGN: list of strings
 #
 # @public
 #
 function(ament_copyright)
-  cmake_parse_arguments(ARG "" "TESTNAME" "" ${ARGN})
+  cmake_parse_arguments(ARG "" "TESTNAME;TIMEOUT" "" ${ARGN})
   if(NOT ARG_TESTNAME)
     set(ARG_TESTNAME "copyright")
+  endif()
+  if(NOT ARG_TIMEOUT)
+    set(ARG_TIMEOUT 120)
   endif()
 
   find_program(ament_copyright_BIN NAMES "ament_copyright")
@@ -44,6 +49,7 @@ function(ament_copyright)
     OUTPUT_FILE "${CMAKE_BINARY_DIR}/ament_copyright/${ARG_TESTNAME}.txt"
     RESULT_FILE "${result_file}"
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    TIMEOUT "${ARG_TIMEOUT}"
   )
   set_tests_properties(
     "${ARG_TESTNAME}"


### PR DESCRIPTION
Fix flaky linter tests due to reaching the timeout of 60s on Windows debug in larger packages, e.g. https://ci.ros2.org/view/nightly/job/nightly_win_deb/1673/testReport/(root)/rclcpp/copyright_xunit_missing_result/

E.g. in this job the test passed in 59.88s: https://ci.ros2.org/view/nightly/job/nightly_win_deb/1664/consoleFull

Windows Debug build testing `ament_cmake_copyright` and `rclcpp`: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11271)](https://ci.ros2.org/job/ci_windows/11271/)