### PR TITLE
remove use of "extend" action in argparse

### DIFF
--- a/ament_pep257/ament_pep257/main.py
+++ b/ament_pep257/ament_pep257/main.py
@@ -64,13 +64,11 @@ def main(argv=sys.argv[1:]):
     err_code_group.add_argument(
         '--ignore',
         nargs='+',
-        action='extend',
         default=[],
         help='Choose the list of error codes for pydocstyle NOT to check for.')
     err_code_group.add_argument(
         '--select',
         nargs='+',
-        action='extend',
         default=[],
         help='Choose the basic list of error codes for pydocstyle to check for.'
     )
@@ -86,13 +84,11 @@ def main(argv=sys.argv[1:]):
     parser.add_argument(
         '--add-ignore',
         nargs='+',
-        action='extend',
         default=[],
         help='Ignore an extra error code, removing it from the list set by --(select/ignore)')
     parser.add_argument(
         '--add-select',
         nargs='+',
-        action='extend',
         default=[],
         help='Check an extra error code, adding it to the list set by --(select/ignore).'
     )


### PR DESCRIPTION
removed an ultimately unnecessary python 3.8 argparse feature, `action=extend`, in order to maintain compatibility with Foxy.

Signed-off-by: Ted Kern <ted.kern@canonical.com>