### PR TITLE
Suppress cppcheck unknownMacro

### DIFF
--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -140,7 +140,8 @@ def main(argv=sys.argv[1:]):
            '-rp',
            '--xml',
            '--xml-version=2',
-           '--suppress=internalAstError']
+           '--suppress=internalAstError',
+           '--suppress=unknownMacro']
     if args.language:
         cmd.extend(['--language={0}'.format(args.language)])
     for include_dir in (args.include_dirs or []):


### PR DESCRIPTION
cppcheck creates an unknownMacro error when it cannot resolve a macro.
Since we don't pass in all dependent headers, we don't expect all macros to be discoverable by cppcheck.