### PR TITLE
Increase the ament_cppcheck timeout to 5 minutes.

### DIFF
--- a/ament_cmake_cppcheck/cmake/ament_cppcheck.cmake
+++ b/ament_cmake_cppcheck/cmake/ament_cppcheck.cmake
@@ -61,7 +61,7 @@ function(ament_cppcheck)
   ament_add_test(
     "${ARG_TESTNAME}"
     COMMAND ${cmd}
-    TIMEOUT 180
+    TIMEOUT 300
     OUTPUT_FILE "${CMAKE_BINARY_DIR}/ament_cppcheck/${ARG_TESTNAME}.txt"
     RESULT_FILE "${result_file}"
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"


### PR DESCRIPTION
This will avoid timeouts on some slower platforms that we've
started to see.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This fixes https://github.com/ros2/rclcpp/issues/1289