### PR TITLE
Use correct lint package dependencies

### DIFF
--- a/ament_lint_auto/doc/index.rst
+++ b/ament_lint_auto/doc/index.rst
@@ -24,9 +24,9 @@ test dependencies.
     <test_depend>ament_lint_auto</test_depend>
 
     <!-- add test dependencies on any linter, e.g. -->
-    <test_depend>ament_clang_format</test_depend>
-    <test_depend>ament_cppcheck</test_depend>
-    <test_depend>ament_pycodestyle</test_depend>
+    <test_depend>ament_cmake_clang_format</test_depend>
+    <test_depend>ament_cmake_cppcheck</test_depend>
+    <test_depend>ament_cmake_pycodestyle</test_depend>
 
 Since recursive dependencies are also being used a single test dependency is
 sufficient to test with a set of common linters.


### PR DESCRIPTION
This PR updates the documentation to match:

https://github.com/ament/ament_lint/blob/master/ament_cmake_cppcheck/doc/index.rst#how-to-run-the-check-from-within-a-cmake-ament-package-as-part-of-the-tests
https://github.com/ament/ament_lint/blob/master/ament_cmake_pycodestyle/doc/index.rst#how-to-run-the-check-from-within-a-cmake-ament-package-as-part-of-the-tests
https://github.com/ament/ament_lint/blob/master/ament_cmake_clang_format/doc/index.rst#how-to-run-the-check-from-within-a-cmake-ament-package-as-part-of-the-tests

according to these links, the packages that need to be added to `package.xml` seem to be `ament_cmake_${LINTER}`.