### PR TITLE
Remove dependency on broken package pyhon3-flake8

### DIFF
--- a/ament_flake8/package.xml
+++ b/ament_flake8/package.xml
@@ -11,7 +11,6 @@
   <author email="dhood@osrfoundation.org">D. Hood</author>
 
   <exec_depend>ament_lint</exec_depend>
-  <exec_depend>python3-flake8</exec_depend>
 
   <export>
     <build_type>ament_python</build_type>


### PR DESCRIPTION
Signed-off-by: Tyler Weaver <tylerjw@gmail.com>

This should fix this issue: https://github.com/ament/ament_lint/issues/279

The problem is the released versions of python3-flake8 in debians is broken for now because it doesn't handle the fact that the latest verion of flake8 depends on a newer version of pycodestyle.  If you instead isntall flake8 using pip3 like this: `pip3 install flake8` it works just fine.  I don't know how pip dependencies are defined for CI so this may not be a complete solution.  It did enable me to use this from source locally though.