### PR TITLE
Add --clang-format-version option

### DIFF
--- a/ament_clang_format/ament_clang_format/main.py
+++ b/ament_clang_format/ament_clang_format/main.py
@@ -48,6 +48,9 @@ def main(argv=sys.argv[1:]):
              'in %s will be considered.' %
              ', '.join(["'.%s'" % e for e in extensions]))
     parser.add_argument(
+        '--clang-format-version',
+        help='The version of clang-format to use.')
+    parser.add_argument(
         '--reformat',
         action='store_true',
         help='Reformat the files in place')
@@ -80,6 +83,10 @@ def main(argv=sys.argv[1:]):
         'clang-format-3.4',
         'clang-format-3.3',
     ]
+
+    if args.clang_format_version:
+        bin_names = ['clang-format-' + args.clang_format_version]
+
     clang_format_bin = find_executable(bin_names)
     if not clang_format_bin:
         print('Could not find %s executable' %

--- a/ament_clang_format/doc/index.rst
+++ b/ament_clang_format/doc/index.rst
@@ -12,9 +12,22 @@ How to run the check from the command line?
 
 .. code:: sh
 
-    ament_clang_format [<path> ...]
+    ament_clang_format [-h] [--config path]
+                       [--clang-format-version CLANG_FORMAT_VERSION]
+                       [--reformat] [--xunit-file XUNIT_FILE]
+                       [paths [paths ...]]
+
+``paths`` are directories to recursively search for files to run clang-format
+on.  If no ``paths`` option is set the current directory will be used.
+
+The ``--config`` allows you to set the path to the .clang-format file to use.
+
+The ``--clang-format-version`` enables you to set a different version of
+clang-format to use.
 
 When using the option ``--reformat`` the proposed changes are applied in place.
+
+The ``--xunit-file`` option is used to generate a xunit output file.
 
 
 How to run the check from within a CMake ament package as part of the tests?


### PR DESCRIPTION
Signed-off-by: Tyler Weaver <tylerjw@gmail.com>

## Description
I am using clang-format-10.  This change would enable me to use ament_clang_format with clang-format-10.  Note that `find_executable` will return as soon as it finds a valid executable.  This means that if we search in this order searching for `clang-format-` first causes no harm in the case where the user does not provide a value for this.

### Follow-on work (for other PRs)
* `ament_cmake_clang_format` should be updated to enable using this option from cmake.
* Would it be a good practice to search the filesystem for a .clang_format file in the working directory or in a parent and use that instead if it exists for the config?  This would simplify running ament_clang_format in a repo that contains a config.  If this default behavior would be accepted, it should also be done for clang-tidy.