### PR TITLE
WIP: Add --clang-tidy-version option to ament_clang_tidy

### DIFF
--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -78,6 +78,10 @@ def main(argv=sys.argv[1:]):
         action='store_true',
         help='Displays errors from all system headers')
     parser.add_argument(
+        '--clang-tidy-version',
+        default='6.0',
+        help='The version of clang-tidy to use.')
+    parser.add_argument(
         '--xunit-file',
         help='Generate a xunit compliant XML file')
     args = parser.parse_args(argv)
@@ -97,8 +101,9 @@ def main(argv=sys.argv[1:]):
 
     bin_names = [
         # 'clang-tidy',
-        'clang-tidy-6.0',
+        'clang-tidy-' + args.clang_tidy_version,
     ]
+
     clang_tidy_bin = find_executable(bin_names)
     if not clang_tidy_bin:
         print('Could not find %s executable' %

--- a/ament_clang_tidy/doc/index.rst
+++ b/ament_clang_tidy/doc/index.rst
@@ -16,9 +16,15 @@ have already been installed. ``compile_commands.json`` files should have already
 
 .. code:: sh
 
-    ament_clang_tidy [<path> ...]
+    ament_clang_tidy [-h] [--config path] [--explain-config]
+                     [--export-fixes EXPORT_FIXES] [--fix-errors]
+                     [--header-filter HEADER_FILTER] [--quiet]
+                     [--system-headers]
+                     [--clang-tidy-version CLANG_TIDY_VERSION]
+                     [--xunit-file XUNIT_FILE]
+                     [paths [paths ...]]
 
-If ``<path>`` is a directory, it will be recursively searched for
+If ``<paths>`` is a directory, it will be recursively searched for
 "compile_commands.json" files (this is usually the ``build`` directory of a
 ``colcon`` workspace). If ``<path>`` is a file, it will be treated as a
 "compile_commands.json" file.
@@ -41,6 +47,9 @@ warnings and warnings treated as errors.
 
 The ``--system-headers`` option will display errors from all system header
 files.
+
+The ``--clang-tidy-version`` enables you to set a different version of
+clang-tidy to use.
 
 The ``--xunit-file`` option will generate a xunit compliant XML file when
 supplied with a file name.


### PR DESCRIPTION
Signed-off-by: Tyler Weaver <tylerjw@gmail.com>

This also contains some of the cleanup of the doc from the --packages-select PR.  As pointed out [here](https://github.com/ament/ament_lint/pull/287) these are not all the changes needed to support clang-tidy-10.