### PR TITLE
Support Python 3.8-provided importlib.metadata

### DIFF
--- a/ament_copyright/ament_copyright/__init__.py
+++ b/ament_copyright/ament_copyright/__init__.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import importlib_metadata
+try:
+    import importlib.metadata as importlib_metadata
+except ModuleNotFoundError:
+    import importlib_metadata
 
 
 COPYRIGHT_GROUP = 'ament_copyright.copyright_name'


### PR DESCRIPTION
The importlib_metadata package is a backport of the importlib.metadata module from Python 3.8. Fedora (and possibly others) no longer package importlib_metadata because they ship Python versions which have the functionality built-in.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13457)](http://ci.ros2.org/job/ci_linux/13457/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8368)](http://ci.ros2.org/job/ci_linux-aarch64/8368/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11181)](http://ci.ros2.org/job/ci_osx/11181/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13521)](http://ci.ros2.org/job/ci_windows/13521/)