### PR TITLE
Ignore flake8-blind-except B902

### DIFF
--- a/ament_flake8/ament_flake8/configuration/ament_flake8.ini
+++ b/ament_flake8/ament_flake8/configuration/ament_flake8.ini
@@ -1,5 +1,5 @@
 [flake8]
-extend-ignore = C816,D100,D101,D102,D103,D104,D105,D106,D107,D203,D212,D404,I202
+extend-ignore = B902,C816,D100,D101,D102,D103,D104,D105,D106,D107,D203,D212,D404,I202
 import-order-style = google
 max-line-length = 99
 show-source = true


### PR DESCRIPTION
Right now, flake8-blind-except doesn't take into account an except block which re-raises the exception, which seems like an acceptable pattern.

Tracked upstream as elijahandrews/flake8-blind-except#7