### PR TITLE
Fix file exclusion behavior in ament_cppcheck and ament_cpplint

### DIFF
--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -68,8 +68,8 @@ def main(argv=sys.argv[1:]):
     parser.add_argument(
         '--exclude',
         nargs='*',
-        help="Exclude files or directories for C/C++ files being checked."
-             "Each files is passed to cppcheck as '--suppress='")
+        help="Exclude C/C++ files from being checked."
+             "Each file is passed to cppcheck as '--suppress=*:<file>'")
     parser.add_argument(
         '--language',
         help="Passed to cppcheck as '--language=<language>', and it forces cppcheck to consider "
@@ -147,7 +147,7 @@ def main(argv=sys.argv[1:]):
     for include_dir in (args.include_dirs or []):
         cmd.extend(['-I', include_dir])
     for exclude in (args.exclude or []):
-        cmd.extend(['--suppress=*:', exclude])
+        cmd.extend(['--suppress=*:' + exclude])
     if jobs:
         cmd.extend(['-j', '%d' % jobs])
     cmd.extend(files)

--- a/ament_cpplint/ament_cpplint/main.py
+++ b/ament_cpplint/ament_cpplint/main.py
@@ -231,7 +231,7 @@ def get_file_groups(paths, extensions, exclude_patterns):
                             append_file_to_group(groups, filepath)
 
         if os.path.isfile(path):
-            if path not in excludes:
+            if os.path.realpath(path) not in excludes:
                 append_file_to_group(groups, path)
 
     return groups

--- a/ament_cpplint/ament_cpplint/main.py
+++ b/ament_cpplint/ament_cpplint/main.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import argparse
+import glob
 import os
 import re
 import sys
@@ -78,6 +79,10 @@ def main(argv=sys.argv[1:]):
         '--root', type=str,
         help='The --root option for cpplint')
     parser.add_argument(
+        '--exclude', default=[],
+        nargs='*',
+        help='Exclude C/C++ files from being checked.')
+    parser.add_argument(
         'paths',
         nargs='*',
         default=[os.curdir],
@@ -119,14 +124,13 @@ def main(argv=sys.argv[1:]):
 
     argv.append('--linelength=%d' % args.linelength)
 
-    groups = get_file_groups(args.paths, extensions + headers)
+    groups = get_file_groups(args.paths, extensions + headers, args.exclude)
     if not groups:
         print('No files found', file=sys.stderr)
         return 1
 
     # hook into error reporting
-    import ament_cpplint.cpplint
-    DefaultError = ament_cpplint.cpplint.Error  # noqa: N806
+    DefaultError = cpplint.Error  # noqa: N806
     report = []
 
     # invoke cpplint for each root group of files
@@ -144,6 +148,7 @@ def main(argv=sys.argv[1:]):
         else:
             print("Not using '--root'")
         print('')
+
         arguments += files
         filenames = ParseArguments(arguments)
 
@@ -152,7 +157,7 @@ def main(argv=sys.argv[1:]):
             errors = []
 
             def custom_error(filename, linenum, category, confidence, message):
-                if ament_cpplint.cpplint._ShouldPrintError(category, confidence, linenum):
+                if cpplint._ShouldPrintError(category, confidence, linenum):
                     errors.append({
                         'linenum': linenum,
                         'category': category,
@@ -160,7 +165,7 @@ def main(argv=sys.argv[1:]):
                         'message': message,
                     })
                 DefaultError(filename, linenum, category, confidence, message)
-            ament_cpplint.cpplint.Error = custom_error
+            cpplint.Error = custom_error
 
             ProcessFile(filename, _cpplint_state.verbose_level)
             report.append((filename, errors))
@@ -199,7 +204,12 @@ def main(argv=sys.argv[1:]):
     return 1 if _cpplint_state.error_count else 0
 
 
-def get_file_groups(paths, extensions):
+def get_file_groups(paths, extensions, exclude_patterns):
+    excludes = []
+    for exclude_pattern in exclude_patterns:
+        excludes.extend(glob.glob(exclude_pattern))
+    excludes = set([os.path.realpath(x) for x in excludes])
+
     # dict mapping root path to files
     groups = {}
     for path in paths:
@@ -216,10 +226,14 @@ def get_file_groups(paths, extensions):
                 for filename in sorted(filenames):
                     _, ext = os.path.splitext(filename)
                     if ext in ('.%s' % e for e in extensions):
-                        append_file_to_group(groups,
-                                             os.path.join(dirpath, filename))
+                        filepath = os.path.join(dirpath, filename)
+                        if not os.path.realpath(filepath) in excludes:
+                            append_file_to_group(groups, filepath)
+
         if os.path.isfile(path):
-            append_file_to_group(groups, path)
+            if not path in excludes:
+                append_file_to_group(groups, path)
+
     return groups
 
 

--- a/ament_cpplint/ament_cpplint/main.py
+++ b/ament_cpplint/ament_cpplint/main.py
@@ -208,7 +208,7 @@ def get_file_groups(paths, extensions, exclude_patterns):
     excludes = []
     for exclude_pattern in exclude_patterns:
         excludes.extend(glob.glob(exclude_pattern))
-    excludes = set([os.path.realpath(x) for x in excludes])
+    excludes = {os.path.realpath(x) for x in excludes}
 
     # dict mapping root path to files
     groups = {}
@@ -227,11 +227,11 @@ def get_file_groups(paths, extensions, exclude_patterns):
                     _, ext = os.path.splitext(filename)
                     if ext in ('.%s' % e for e in extensions):
                         filepath = os.path.join(dirpath, filename)
-                        if not os.path.realpath(filepath) in excludes:
+                        if os.path.realpath(filepath) not in excludes:
                             append_file_to_group(groups, filepath)
 
         if os.path.isfile(path):
-            if not path in excludes:
+            if path not in excludes:
                 append_file_to_group(groups, path)
 
     return groups


### PR DESCRIPTION
Closes https://github.com/ament/ament_lint/issues/295

This pull request fixes the issue described at https://github.com/ament/ament_lint/pull/234#discussion_r575866499 and possibly replaces https://github.com/ament/ament_lint/pull/238.

This pull request also makes the behavior between `ament_cppcheck` and `ament_cpplint` consistent.