### PR TITLE
Add ament_cmake_clang_tidy to ament_lint_common

### DIFF
--- a/ament_cmake_clang_tidy/cmake/ament_cmake_clang_tidy_lint_hook.cmake
+++ b/ament_cmake_clang_tidy/cmake/ament_cmake_clang_tidy_lint_hook.cmake
@@ -24,5 +24,5 @@ file(GLOB_RECURSE _source_files FOLLOW_SYMLINKS
 )
 if(_source_files)
   message(STATUS "Added test 'clang_tidy' to check C / C++ code style")
-  ament_clang_tidy()
+  ament_clang_tidy(${CMAKE_BINARY_DIR})
 endif()

--- a/ament_lint_common/package.xml
+++ b/ament_lint_common/package.xml
@@ -16,7 +16,7 @@
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
 
   <!--<exec_depend>ament_clang_format</exec_depend>-->
-  <!--<exec_depend>ament_clang_tidy</exec_depend>-->
+  <exec_depend>ament_cmake_clang_tidy</exec_depend>
   <exec_depend>ament_cmake_copyright</exec_depend>
   <exec_depend>ament_cmake_cppcheck</exec_depend>
   <exec_depend>ament_cmake_cpplint</exec_depend>


### PR DESCRIPTION
Closes https://github.com/ament/ament_lint/issues/283

This pull request will make `ament_clang_tidy` one of the default linters that get run during `colcon test`.