### PR TITLE
ament_lint_cmake: default linelength in argumentparser for consistency

### DIFF
--- a/ament_cmake_lint_cmake/cmake/ament_lint_cmake.cmake
+++ b/ament_cmake_lint_cmake/cmake/ament_lint_cmake.cmake
@@ -40,8 +40,6 @@ function(ament_lint_cmake)
   set(cmd "${ament_lint_cmake_BIN}" "--xunit-file" "${result_file}")
   if(DEFINED ARG_MAX_LINE_LENGTH)
     list(APPEND cmd "--linelength" "${ARG_MAX_LINE_LENGTH}")
-  else()
-    list(APPEND cmd "--linelength" "140")
   endif()
   list(APPEND cmd ${ARG_UNPARSED_ARGUMENTS})
 

--- a/ament_lint_cmake/ament_lint_cmake/main.py
+++ b/ament_lint_cmake/ament_lint_cmake/main.py
@@ -49,7 +49,7 @@ def main(argv=sys.argv[1:]):
         help='Filters for lint_cmake, for a list of filters see: '
              'https://github.com/richq/cmake-lint/blob/master/README.md#usage')
     parser.add_argument(
-        '--linelength', metavar='N', type=int,
+        '--linelength', metavar='N', type=int, default=140,
         help='The maximum line length')
     # not using a file handle directly
     # in order to prevent leaving an empty file when something fails early


### PR DESCRIPTION
Fixes #301 
Related to https://github.com/ros-tooling/action-ros-lint/pull/246