### PR TITLE
Use non-blind except for open()

### DIFF
--- a/ament_copyright/ament_copyright/licenses.py
+++ b/ament_copyright/ament_copyright/licenses.py
@@ -37,7 +37,7 @@ def read_data(path, name, prefix, license_type):
             with open(path_template % index, 'r') as h:
                 data.append(h.read())
                 index += 1
-        except Exception:
+        except OSError:
             break
 
     return data


### PR DESCRIPTION
Follow-up to #304

CI uses `flake8-blind-except==0.1.1`: https://ci.ros2.org/job/ci_linux/13949/consoleFull#console-section-9. However, using the newest version (0.2.0) leads to a flake8 error:

```
./ament_copyright/licenses.py:40:1: B902 blind except Exception: statement
```

I thought I'd propose this change for others like me who build from source and often use the latest versions.

Relates to #292 a bit