### PR TITLE
Improvements to ament_lint_clang_tidy.

### DIFF
--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -112,7 +112,9 @@ def main(argv=sys.argv[1:]):
         return 1
 
     bin_names = [
-        # 'clang-tidy',
+        'clang-tidy',
+        'clang-tidy-10',
+        'clang-tidy-11',
         'clang-tidy-6.0',
     ]
     clang_tidy_bin = find_executable(bin_names)

--- a/ament_cmake_clang_tidy/cmake/ament_cmake_clang_tidy_lint_hook.cmake
+++ b/ament_cmake_clang_tidy/cmake/ament_cmake_clang_tidy_lint_hook.cmake
@@ -24,5 +24,5 @@ file(GLOB_RECURSE _source_files FOLLOW_SYMLINKS
 )
 if(_source_files)
   message(STATUS "Added test 'clang_tidy' to check C / C++ code style")
-  ament_clang_tidy()
+  ament_clang_tidy("${CMAKE_CURRENT_BINARY_DIR}")
 endif()


### PR DESCRIPTION
Without this default in the hook script ament_clang_tidy does not execute properly.

This is still in draft while I determine why a default is needed in CMake when the python script wrapping clang-tidy should be handling the default instead.

The second commit updates the script to check for more than just clang-tidy-6.0.