### PR TITLE
Enable MISRA checking in cppcheck

### DIFF
--- a/ament_cmake_cppcheck/cmake/ament_cmake_cppcheck_lint_hook.cmake
+++ b/ament_cmake_cppcheck/cmake/ament_cmake_cppcheck_lint_hook.cmake
@@ -81,6 +81,6 @@ if(_source_files)
     STATUS "Configured cppcheck exclude dirs and/or files: ${_all_exclude}"
   )
   ament_cppcheck(
-    ${_language} INCLUDE_DIRS ${_all_include_dirs} EXCLUDE ${_all_exclude}
+    MISRA ${_language} INCLUDE_DIRS ${_all_include_dirs} EXCLUDE ${_all_exclude}
   )
 endif()

--- a/ament_cmake_cppcheck/cmake/ament_cppcheck.cmake
+++ b/ament_cmake_cppcheck/cmake/ament_cppcheck.cmake
@@ -33,7 +33,7 @@
 # @public
 #
 function(ament_cppcheck)
-  cmake_parse_arguments(ARG "MISRA" "EXCLUDE;LANGUAGE;TESTNAME" "INCLUDE_DIRS" ${ARGN})
+  cmake_parse_arguments(ARG "" "EXCLUDE;LANGUAGE;TESTNAME;MISRA" "INCLUDE_DIRS" ${ARGN})
   if(NOT ARG_TESTNAME)
     set(ARG_TESTNAME "cppcheck")
   endif()
@@ -56,8 +56,8 @@ function(ament_cppcheck)
     string(TOLOWER ${ARG_LANGUAGE} ARG_LANGUAGE)
     list(APPEND cmd "--language" "${ARG_LANGUAGE}")
   endif()
-  if(ARG_MISRA)
-    list(APPEND cmd "--misra")
+  if(ARG_MISRA STREQUAL "OFF")
+    list(APPEND cmd "--disable-misra-checks")
   endif()
 
   file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/ament_cppcheck")

--- a/ament_cmake_cppcheck/cmake/ament_cppcheck.cmake
+++ b/ament_cmake_cppcheck/cmake/ament_cppcheck.cmake
@@ -33,7 +33,7 @@
 # @public
 #
 function(ament_cppcheck)
-  cmake_parse_arguments(ARG "" "EXCLUDE;LANGUAGE;TESTNAME" "INCLUDE_DIRS" ${ARGN})
+  cmake_parse_arguments(ARG "MISRA" "EXCLUDE;LANGUAGE;TESTNAME" "INCLUDE_DIRS" ${ARGN})
   if(NOT ARG_TESTNAME)
     set(ARG_TESTNAME "cppcheck")
   endif()
@@ -55,6 +55,9 @@ function(ament_cppcheck)
   if(ARG_LANGUAGE)
     string(TOLOWER ${ARG_LANGUAGE} ARG_LANGUAGE)
     list(APPEND cmd "--language" "${ARG_LANGUAGE}")
+  endif()
+  if(ARG_MISRA)
+    list(APPEND cmd "--misra")
   endif()
 
   file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/ament_cppcheck")

--- a/ament_cmake_cppcheck/cmake/ament_cppcheck.cmake
+++ b/ament_cmake_cppcheck/cmake/ament_cppcheck.cmake
@@ -27,6 +27,8 @@
 # :type EXCLUDE: list
 # :param INCLUDE_DIRS: an optional list of include paths for cppcheck
 # :type INCLUDE_DIRS: list
+# :param MISRA: whether to enable the MISRA 2012 addon
+# :type MISRA: option
 # :param ARGN: the files or directories to check
 # :type ARGN: list of strings
 #
@@ -57,7 +59,7 @@ function(ament_cppcheck)
     list(APPEND cmd "--language" "${ARG_LANGUAGE}")
   endif()
   if(ARG_MISRA)
-    list(APPEND cmd "--misra")
+    list(APPEND cmd "--enable-misra-checks")
   endif()
 
   file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/ament_cppcheck")

--- a/ament_cmake_cppcheck/cmake/ament_cppcheck.cmake
+++ b/ament_cmake_cppcheck/cmake/ament_cppcheck.cmake
@@ -33,7 +33,7 @@
 # @public
 #
 function(ament_cppcheck)
-  cmake_parse_arguments(ARG "" "EXCLUDE;LANGUAGE;TESTNAME;MISRA" "INCLUDE_DIRS" ${ARGN})
+  cmake_parse_arguments(ARG "MISRA" "EXCLUDE;LANGUAGE;TESTNAME" "INCLUDE_DIRS" ${ARGN})
   if(NOT ARG_TESTNAME)
     set(ARG_TESTNAME "cppcheck")
   endif()
@@ -56,8 +56,8 @@ function(ament_cppcheck)
     string(TOLOWER ${ARG_LANGUAGE} ARG_LANGUAGE)
     list(APPEND cmd "--language" "${ARG_LANGUAGE}")
   endif()
-  if(ARG_MISRA STREQUAL "OFF")
-    list(APPEND cmd "--disable-misra-checks")
+  if(ARG_MISRA)
+    list(APPEND cmd "--misra")
   endif()
 
   file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/ament_cppcheck")

--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -85,9 +85,9 @@ def main(argv=sys.argv[1:]):
         action='store_true',
         help='Get the cppcheck version, print it, and then exit.')
     parser.add_argument(
-        '--disable-misra-checks',
+        '--misra',
         action='store_true',
-        help="Disable the checks that evaluate compliance with the MISRA coding standard.")
+        help="Evaluate compliance with the MISRA coding standard.")
     args = parser.parse_args(argv)
 
     cppcheck_bin = find_cppcheck_executable()
@@ -154,7 +154,7 @@ def main(argv=sys.argv[1:]):
         cmd.extend(['--suppress=*:' + exclude])
     if jobs:
         cmd.extend(['-j', '%d' % jobs])
-    if not args.disable_misra_checks:
+    if args.misra:
         cmd.extend(['--addon=misra'])
     cmd.extend(files)
     try:

--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -85,9 +85,9 @@ def main(argv=sys.argv[1:]):
         action='store_true',
         help='Get the cppcheck version, print it, and then exit.')
     parser.add_argument(
-        '--misra',
+        '--enable-misra-checks',
         action='store_true',
-        help="Evaluate compliance with the MISRA coding standard.")
+        help="Enable the MISRA C 2012 compliance checking addon.")
     args = parser.parse_args(argv)
 
     cppcheck_bin = find_cppcheck_executable()
@@ -154,7 +154,7 @@ def main(argv=sys.argv[1:]):
         cmd.extend(['--suppress=*:' + exclude])
     if jobs:
         cmd.extend(['-j', '%d' % jobs])
-    if args.misra:
+    if args.enable_misra_checks:
         cmd.extend(['--addon=misra'])
     cmd.extend(files)
     try:

--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -84,6 +84,10 @@ def main(argv=sys.argv[1:]):
         '--cppcheck-version',
         action='store_true',
         help='Get the cppcheck version, print it, and then exit.')
+    parser.add_argument(
+        '--misra',
+        action='store_true',
+        help="Evaluate compliance with the MISRA coding standard.")
     args = parser.parse_args(argv)
 
     cppcheck_bin = find_cppcheck_executable()
@@ -150,6 +154,8 @@ def main(argv=sys.argv[1:]):
         cmd.extend(['--suppress=*:' + exclude])
     if jobs:
         cmd.extend(['-j', '%d' % jobs])
+    if args.misra:
+        cmd.extend(['--addon=misra'])
     cmd.extend(files)
     try:
         p = subprocess.Popen(cmd, stderr=subprocess.PIPE)

--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -85,9 +85,9 @@ def main(argv=sys.argv[1:]):
         action='store_true',
         help='Get the cppcheck version, print it, and then exit.')
     parser.add_argument(
-        '--misra',
+        '--disable-misra-checks',
         action='store_true',
-        help="Evaluate compliance with the MISRA coding standard.")
+        help="Disable the checks that evaluate compliance with the MISRA coding standard.")
     args = parser.parse_args(argv)
 
     cppcheck_bin = find_cppcheck_executable()
@@ -154,7 +154,7 @@ def main(argv=sys.argv[1:]):
         cmd.extend(['--suppress=*:' + exclude])
     if jobs:
         cmd.extend(['-j', '%d' % jobs])
-    if args.misra:
+    if not args.disable_misra_checks:
         cmd.extend(['--addon=misra'])
     cmd.extend(files)
     try:


### PR DESCRIPTION
For Space ROS, the --misra option to cppcheck is enabled by default from ament_cppcheck, since MISRA checking will be required, and a command-line option introduced to disable it. 