### PR TITLE
adding cppcheck libraries option

### DIFF
--- a/ament_cmake_cppcheck/cmake/ament_cppcheck.cmake
+++ b/ament_cmake_cppcheck/cmake/ament_cppcheck.cmake
@@ -23,6 +23,8 @@
 # :type TESTNAME: string
 # :param LANGUAGE: the language argument for cppcheck, either 'c' or 'c++'
 # :type LANGUAGE: string
+# :param LIBRARIES: an optional list of library configs for cppcheck to load
+# :type LIBRARIES: list
 # :param EXCLUDE: an optional list of exclude files or directories for cppcheck
 # :type EXCLUDE: list
 # :param INCLUDE_DIRS: an optional list of include paths for cppcheck
@@ -33,7 +35,7 @@
 # @public
 #
 function(ament_cppcheck)
-  cmake_parse_arguments(ARG "" "EXCLUDE;LANGUAGE;TESTNAME" "INCLUDE_DIRS" ${ARGN})
+  cmake_parse_arguments(ARG "" "EXCLUDE;LANGUAGE;TESTNAME" "LIBRARIES;INCLUDE_DIRS" ${ARGN})
   if(NOT ARG_TESTNAME)
     set(ARG_TESTNAME "cppcheck")
   endif()
@@ -49,12 +51,15 @@ function(ament_cppcheck)
   if(ARG_EXCLUDE)
     list(APPEND cmd "--exclude" "${ARG_EXCLUDE}")
   endif()
-  if(ARG_INCLUDE_DIRS)
-    list(APPEND cmd "--include_dirs" "${ARG_INCLUDE_DIRS}")
-  endif()
   if(ARG_LANGUAGE)
     string(TOLOWER ${ARG_LANGUAGE} ARG_LANGUAGE)
     list(APPEND cmd "--language" "${ARG_LANGUAGE}")
+  endif()
+  if(ARG_LIBRARIES)
+    list(APPEND cmd "--libraries" "${ARG_LIBRARIES}")
+  endif()
+  if(ARG_INCLUDE_DIRS)
+    list(APPEND cmd "--include_dirs" "${ARG_INCLUDE_DIRS}")
   endif()
 
   file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/ament_cppcheck")

--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -61,6 +61,11 @@ def main(argv=sys.argv[1:]):
              'files ending in one of %s.' %
              ', '.join(["'.%s'" % e for e in extensions]))
     parser.add_argument(
+        '--libraries',
+        nargs='*',
+        help="Library configurations to load in addition to the standard libraries of C and C++."
+             "Each library is passed to cppcheck as '--library=<library_name>'")
+    parser.add_argument(
         '--include_dirs',
         nargs='*',
         help="Include directories for C/C++ files being checked."
@@ -144,6 +149,8 @@ def main(argv=sys.argv[1:]):
            '--suppress=unknownMacro']
     if args.language:
         cmd.extend(['--language={0}'.format(args.language)])
+    for library in (args.libraries or []):
+        cmd.extend(['--library={0}'.format(library)])
     for include_dir in (args.include_dirs or []):
         cmd.extend(['-I', include_dir])
     for exclude in (args.exclude or []):


### PR DESCRIPTION
I am adding a `libraries` option to `ament_cppcheck` that is passed to `cppcheck`. See the cppcheck documentation http://cppcheck.net/manual.html#library-configuration for an explanation of what this option does.

Here is an example of using `ament_cppcheck` with this option from `CMakeLists.txt`:
```cmake
  find_package(ament_cmake_cppcheck REQUIRED)
  ament_cppcheck(LANGUAGE c++
    LIBRARIES googletest qt
    INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include)
```

This addresses the issue I raised in https://github.com/ament/ament_lint/issues/321