### PR TITLE
[ament_copyright] Fix file exclusion behavior

### DIFF
--- a/ament_copyright/ament_copyright/main.py
+++ b/ament_copyright/ament_copyright/main.py
@@ -58,6 +58,7 @@ def main(argv=sys.argv[1:]):
         '--exclude',
         metavar='filename',
         nargs='*',
+        default=[],
         dest='excludes',
         help='The filenames to exclude.')
     group = parser.add_mutually_exclusive_group()
@@ -107,9 +108,7 @@ def main(argv=sys.argv[1:]):
     if args.xunit_file:
         start_time = time.time()
 
-    filenames = get_files(args.paths, extensions)
-    if args.excludes:
-        filenames = [f for f in filenames if os.path.basename(f) not in args.excludes]
+    filenames = get_files(args.paths, extensions, args.excludes)
     if not filenames:
         print('No repository roots and files found')
 

--- a/ament_copyright/test/cases/crawler/case.py
+++ b/ament_copyright/test/cases/crawler/case.py
@@ -1,0 +1,19 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.

--- a/ament_copyright/test/cases/crawler/case2.cpp
+++ b/ament_copyright/test/cases/crawler/case2.cpp
@@ -1,0 +1,11 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+
+int main()
+{
+  return 0;
+}

--- a/ament_copyright/test/cases/crawler/subdir/case.py
+++ b/ament_copyright/test/cases/crawler/subdir/case.py
@@ -1,0 +1,19 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.

--- a/ament_copyright/test/cases/crawler/subdir/case2.cpp
+++ b/ament_copyright/test/cases/crawler/subdir/case2.cpp
@@ -1,0 +1,11 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+
+int main()
+{
+  return 0;
+}

--- a/ament_copyright/test/test_copyright.py
+++ b/ament_copyright/test/test_copyright.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from contextlib import redirect_stdout
+import io
 import os
 
 from ament_copyright.main import main
 
 
 cases_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'cases')
+f = io.StringIO()
 
 
 def test_apache2_standard():
@@ -72,4 +75,48 @@ def test_mit_py():
 
 def test_mit_cpp():
     rc = main(argv=[os.path.join(cases_path, 'mit/case2.cpp')])
+    assert rc == 0, 'Found errors'
+
+
+def test_incorrect_exclusion():
+    """
+    Checks that excluding a single filename does not work.
+
+    `ament_copyright <path> --exclude <file-name>` should not exclude anything.
+    """
+    rc = main(argv=[os.path.join(cases_path, 'mit/case.py'), '--exclude', 'case.py'])
+    assert rc == 0, 'Found errors'
+
+
+def test_correct_exclusion():
+    """
+    Checks that excluding a file relatively/absolutely works as expected.
+
+    `ament_copyright <path/filename> --exclude <path/filename>` should exclude <path/filename>.
+    """
+    with redirect_stdout(f):
+        rc = main(
+            argv=[
+                os.path.join(cases_path, 'mit/case.py'),
+                '--exclude',
+                os.path.join(cases_path, 'mit/case.py')
+            ])
+    assert 'No repository roots and files found' in f.getvalue()
+    assert rc == 0, 'Found errors'
+
+
+def test_wildcard_exclusion():
+    """
+    Checks that wildcard exclusion works correctly.
+
+    `ament_copyright <path> --exclude <path/*>` should exclude all files in <path>.
+    """
+    with redirect_stdout(f):
+        rc = main(
+            argv=[
+                os.path.join(cases_path, 'mit'),
+                '--exclude',
+                os.path.join(cases_path, 'mit/*')
+            ])
+    assert 'No repository roots and files found' in f.getvalue()
     assert rc == 0, 'Found errors'

--- a/ament_copyright/test/test_crawler.py
+++ b/ament_copyright/test/test_crawler.py
@@ -1,0 +1,75 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+from ament_copyright.crawler import get_files
+
+
+cases_path = Path(__file__).parent / 'cases' / 'crawler'
+extensions = [
+    'c', 'cc', 'cpp', 'cxx', 'h', 'hh', 'hpp', 'hxx',
+    'cmake',
+    'py',
+]
+
+
+def test_search_nested():
+    """Test that files are found across nested directories."""
+    assert len(get_files([cases_path], extensions, [])) == 4
+
+
+def test_search_incorrect_extensions():
+    """Test that extensions are respected during search."""
+    assert not get_files([cases_path], ['java'], [])
+
+
+def test_search_single_file_name():
+    """
+    Test that the crawler finds no files with simply a filename.
+
+    The assumption being that said filename does not exist relative to the test script.
+    """
+    assert not get_files(['case.py'], extensions, [])
+
+
+def test_exclude_file_name_incorrect():
+    """Excluding a single file name should not work, all files found."""
+    excludes = [str('case.py')]
+    assert len(get_files([cases_path], extensions, excludes)) == 4
+
+
+def test_exclude_file_name_correct():
+    """
+    Checks that the crawler excludes a single file if that is excluded relatively/absolutely.
+
+    Plus, checks that nested directories are respected.
+    """
+    excludes = [str(cases_path / 'case.py')]
+    assert len(get_files([cases_path], extensions, excludes)) == 3
+    excludes = [str(cases_path / 'subdir' / 'case.py')]
+    assert len(get_files([cases_path], extensions, excludes)) == 3
+
+
+def test_exclude_dir():
+    """Excluding a directory alone should not work, all files found."""
+    assert len(get_files([cases_path], extensions, [str(cases_path)])) == 4
+
+
+def test_exclude_wildcard():
+    """Wildcard exclusion should work, and nested directories are respected."""
+    excludes = [str(cases_path / '*')]
+    assert len(get_files([cases_path], extensions, excludes)) == 2
+    excludes = [str(cases_path / 'subdir' / '*')]
+    assert len(get_files([cases_path], extensions, excludes)) == 2

--- a/ament_cpplint/test/test_copyright.py
+++ b/ament_cpplint/test/test_copyright.py
@@ -19,6 +19,6 @@ import pytest
 @pytest.mark.copyright
 @pytest.mark.linter
 def test_copyright():
-    excluded = ['cpplint.py']
+    excluded = ['ament_cpplint/cpplint.py']
     rc = main(argv=['--exclude'] + excluded)
     assert rc == 0, 'Found errors'

--- a/ament_lint_cmake/test/test_copyright.py
+++ b/ament_lint_cmake/test/test_copyright.py
@@ -19,6 +19,6 @@ import pytest
 @pytest.mark.copyright
 @pytest.mark.linter
 def test_copyright():
-    excluded = ['cmakelint.py']
+    excluded = ['ament_lint_cmake/cmakelint.py']
     rc = main(argv=['--exclude'] + excluded)
     assert rc == 0, 'Found errors'

--- a/ament_pclint/test/test_copyright.py
+++ b/ament_pclint/test/test_copyright.py
@@ -20,13 +20,14 @@ import pytest
 @pytest.mark.copyright
 @pytest.mark.linter
 def test_copyright():
+    path_prefix = 'ament_pclint/config/'
     excluded = [
-        'co-g++.h',
-        'co-gcc.h',
-        'co-osx-g++.h',
-        'co-osx-gcc.h',
-        'co-cl.h',
-        'co-cl++.h']
+        'gcc/co-g++.h',
+        'gcc/co-gcc.h',
+        'gcc/co-osx-g++.h',
+        'gcc/co-osx-gcc.h',
+        'msvc/co-cl.h',
+        'msvc/co-cl++.h']
 
-    rc = main(argv=['--exclude'] + excluded)
+    rc = main(argv=['--exclude'] + [path_prefix + fname for fname in excluded])
     assert rc == 0, 'Found errors'


### PR DESCRIPTION
This PR fixes the file exclusion behavior reported in
https://github.com/ament/ament_lint/issues/326.

Specifically, the exclusion list is matched against traversed
files in the `crawler` module.

Changes inspired by https://github.com/ament/ament_lint/pull/299/.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>