### PR TITLE
[ament_cmake_copyright] Add file exclusion support

### DIFF
--- a/ament_cmake_copyright/cmake/ament_copyright.cmake
+++ b/ament_cmake_copyright/cmake/ament_copyright.cmake
@@ -19,13 +19,15 @@
 # :type TESTNAME: string
 # :param TIMEOUT: the test timeout in seconds, default: 120
 # :type TIMEOUT: integer
+# :param EXCLUDE: an optional list of exclude files or directories for cppcheck
+# :type EXCLUDE: list
 # :param ARGN: the files or directories to check
 # :type ARGN: list of strings
 #
 # @public
 #
 function(ament_copyright)
-  cmake_parse_arguments(ARG "" "TESTNAME;TIMEOUT" "" ${ARGN})
+  cmake_parse_arguments(ARG "" "TESTNAME;TIMEOUT" "EXCLUDE" ${ARGN})
   if(NOT ARG_TESTNAME)
     set(ARG_TESTNAME "copyright")
   endif()
@@ -40,6 +42,9 @@ function(ament_copyright)
 
   set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.xunit.xml")
   set(cmd "${ament_copyright_BIN}" "--xunit-file" "${result_file}")
+  if(ARG_EXCLUDE)
+    list(APPEND cmd "--exclude" "${ARG_EXCLUDE}")
+  endif()
   list(APPEND cmd ${ARG_UNPARSED_ARGUMENTS})
 
   file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/ament_copyright")

--- a/ament_cmake_copyright/cmake/ament_copyright.cmake
+++ b/ament_cmake_copyright/cmake/ament_copyright.cmake
@@ -19,7 +19,7 @@
 # :type TESTNAME: string
 # :param TIMEOUT: the test timeout in seconds, default: 120
 # :type TIMEOUT: integer
-# :param EXCLUDE: an optional list of exclude files or directories for cppcheck
+# :param EXCLUDE: an optional list of exclude files or directories for copyright check
 # :type EXCLUDE: list
 # :param ARGN: the files or directories to check
 # :type ARGN: list of strings


### PR DESCRIPTION
In the `ament_copyright` CMake function, the optional list
argument `EXCLUDE` can now be used as an exclusion specifier.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>