### PR TITLE
Ignore .*/_* dirs in ament_flake8

### DIFF
--- a/ament_flake8/ament_flake8/main.py
+++ b/ament_flake8/ament_flake8/main.py
@@ -82,6 +82,9 @@ def main_with_errors(argv=sys.argv[1:]):
         if 'AMENT_IGNORE' in dirnames + filenames:
             dirnames[:] = []
             args.excludes.append(dirpath)
+        else:
+            # ignore folder starting with . or _
+            args.excludes.extend(d for d in dirnames if d[0] in ['.', '_'])
 
     report = generate_flake8_report(
         args.config_file, args.paths, args.excludes,


### PR DESCRIPTION
Other ament_* linters specifically ignore directories starting with a dot or underscore when crawling for files to lint. They also do so implicitly, so this change mimics that same pattern so that the behavior is consistent.

Examples of other ament_* linters with this behavior:
* [ament_copyright](https://github.com/ament/ament_lint/blob/ebd524bb9973d5ec1dc48a670ce54f958a5a0243/ament_copyright/ament_copyright/crawler.py#L34-L35)
* [ament_cpplint](https://github.com/ament/ament_lint/blob/ebd524bb9973d5ec1dc48a670ce54f958a5a0243/ament_cpplint/ament_cpplint/main.py#L221-L222)
* [ament_cppcheck](https://github.com/ament/ament_lint/blob/ebd524bb9973d5ec1dc48a670ce54f958a5a0243/ament_cppcheck/ament_cppcheck/main.py#L236-L237)
* [ament_lint_cmake](https://github.com/ament/ament_lint/blob/ebd524bb9973d5ec1dc48a670ce54f958a5a0243/ament_lint_cmake/ament_lint_cmake/main.py#L136-L137)
* [ament_uncrustify](https://github.com/ament/ament_lint/blob/ebd524bb9973d5ec1dc48a670ce54f958a5a0243/ament_uncrustify/ament_uncrustify/main.py#L231-L232)

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=15523)](http://ci.ros2.org/job/ci_linux/15523/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=10209)](http://ci.ros2.org/job/ci_linux-aarch64/10209/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=13193)](http://ci.ros2.org/job/ci_osx/13193/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=15733)](http://ci.ros2.org/job/ci_windows/15733/)