### PR TITLE
remove google style from clang-tidy default settings

### DIFF
--- a/ament_clang_tidy/ament_clang_tidy/configuration/.clang-tidy
+++ b/ament_clang_tidy/ament_clang_tidy/configuration/.clang-tidy
@@ -1,2 +1,0 @@
-Checks: >
-    google-*,

--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -32,8 +32,6 @@ import yaml
 
 
 def main(argv=sys.argv[1:]):
-    config_file = os.path.join(
-        os.path.dirname(__file__), 'configuration', '.clang-tidy')
     extensions = ['c', 'cc', 'cpp', 'cxx', 'h', 'hh', 'hpp', 'hxx']
 
     parser = argparse.ArgumentParser(
@@ -42,7 +40,7 @@ def main(argv=sys.argv[1:]):
     parser.add_argument(
         '--config',
         metavar='path',
-        default=config_file,
+        default=None,
         dest='config_file',
         help='The config file')
     parser.add_argument(
@@ -91,7 +89,7 @@ def main(argv=sys.argv[1:]):
         help='Generate a xunit compliant XML file')
     args = parser.parse_args(argv)
 
-    if not os.path.exists(args.config_file):
+    if args.config_file is not None and not os.path.exists(args.config_file):
         print("Could not find config file '%s'" % args.config_file,
               file=sys.stderr)
         return 1
@@ -129,13 +127,15 @@ def main(argv=sys.argv[1:]):
         package_dir = os.path.dirname(compilation_db_path)
         package_name = os.path.basename(package_dir)
 
-        with open(args.config_file, 'r') as h:
-            content = h.read()
-        data = yaml.safe_load(content)
-        style = yaml.dump(data, default_flow_style=True, width=float('inf'))
         cmd = [clang_tidy_bin,
-               '--config=%s' % style,
                '-p', package_dir]
+
+        if args.config_file is not None:
+            with open(args.config_file, 'r') as h:
+                content = h.read()
+            data = yaml.safe_load(content)
+            style = yaml.dump(data, default_flow_style=True, width=float('inf'))
+            cmd.append('--config=%s' % style)
         if args.explain_config:
             cmd.append('--explain-config')
         if args.export_fixes:


### PR DESCRIPTION
This also removes the need for default config file.

I propose this change because:

- `cpplint.py` covers these Google style-like checks (things like using explicit on a constructor with one argument)
- these are often false positives, and need to be suppressed, but the suppression mechanism (`// NOLINT(rule)`) is problematic because the name of the rules are different for `cpplint.py` and clang-tidy's version of the rules
- when providing multiple rules clang-tidy emits warnings that it doesn't know the rule name used by `cpplint.py`, causing more unhelpful warnings

The simplest solution, in my opinion, is to remove this from the default settings, rely on `cpplint.py` for these kinds of checks, and let individual users add the Google style checks to their on clang-tidy config files, if they wish to use them.

@nuclearsandwich FYI