### PR TITLE
[ament_uncrustify] Add ament_lint tests

### DIFF
--- a/ament_uncrustify/ament_uncrustify/main.py
+++ b/ament_uncrustify/ament_uncrustify/main.py
@@ -284,7 +284,7 @@ def invoke_uncrustify(
         if e.output:
             print(e.output.decode(), file=sys.stderr)
         print("The invocation of 'uncrustify' failed with error code %d: %s" %
-            (e.returncode, e), file=sys.stderr)
+              (e.returncode, e), file=sys.stderr)
         return None
 
     if cwd:
@@ -298,8 +298,7 @@ def invoke_uncrustify(
         output_files = [
             os.path.join(
                 temp_path,
-                os.sep.join(f.split(os.sep)[1:]) +
-                suffix
+                os.sep.join(f.split(os.sep)[1:]) + suffix
             ) for f in input_files
         ]
 

--- a/ament_uncrustify/package.xml
+++ b/ament_uncrustify/package.xml
@@ -15,6 +15,12 @@
 
   <exec_depend>uncrustify_vendor</exec_depend>
 
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>ament_pycodestyle</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
   <export>
     <build_type>ament_python</build_type>
   </export>

--- a/ament_uncrustify/test/test_copyright.py
+++ b/ament_uncrustify/test/test_copyright.py
@@ -1,0 +1,23 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_copyright.main import main
+import pytest
+
+
+@pytest.mark.copyright
+@pytest.mark.linter
+def test_copyright():
+    rc = main(argv=['.', 'test'])
+    assert rc == 0, 'Found errors'

--- a/ament_uncrustify/test/test_flake8.py
+++ b/ament_uncrustify/test/test_flake8.py
@@ -1,0 +1,25 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_flake8.main import main_with_errors
+import pytest
+
+
+@pytest.mark.flake8
+@pytest.mark.linter
+def test_flake8():
+    rc, errors = main_with_errors(argv=[])
+    assert rc == 0, \
+        'Found %d code style errors / warnings:\n' % len(errors) + \
+        '\n'.join(errors)

--- a/ament_uncrustify/test/test_pep257.py
+++ b/ament_uncrustify/test/test_pep257.py
@@ -1,0 +1,23 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_pep257.main import main
+import pytest
+
+
+@pytest.mark.linter
+@pytest.mark.pep257
+def test_pep257():
+    rc = main(argv=['.', 'test'])
+    assert rc == 0, 'Found code style errors / warnings'

--- a/ament_uncrustify/test/test_pycodestyle.py
+++ b/ament_uncrustify/test/test_pycodestyle.py
@@ -1,0 +1,22 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_pycodestyle.main import main
+import pytest
+
+
+@pytest.mark.linter
+def test_pycodestyle():
+    rc = main(argv=['.', 'test'])
+    assert rc == 0, 'Found code style errors / warnings'


### PR DESCRIPTION
This PR adds `ament_lint` linter tests on the `ament_uncrustify` package. It is a foundation for adding file exclusion behavior tests in #334.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>