### PR TITLE
ignore NOLINT comments with categories that come from clang-tidy

### DIFF
--- a/ament_cpplint/ament_cpplint/cpplint.py
+++ b/ament_cpplint/ament_cpplint/cpplint.py
@@ -279,6 +279,12 @@ _LEGACY_ERROR_CATEGORIES = [
     'readability/function',
     ]
 
+# These prefixes for categories should be ignored since they relate to other
+# tools which also use the NOLINT syntax, e.g. clang-tidy.
+_OTHER_NOLINT_CATEGORY_PREFIXES = [
+    'clang-analyzer',
+    ]
+
 # The default state of the category filter. This is overridden by the --filter=
 # flag. By default all errors are on, so only add here categories that should be
 # off by default (i.e., categories that must be enabled by the --filter= flags).
@@ -608,6 +614,9 @@ def ParseNolintSuppressions(filename, raw_line, linenum, error):
         category = category[1:-1]
         if category in _ERROR_CATEGORIES:
           _error_suppressions.setdefault(category, set()).add(suppressed_line)
+        elif any([c for c in _OTHER_NOLINT_CATEGORY_PREFIXES if category.startswith(c)]):
+          # Ignore any categories from other tools.
+          pass
         elif category not in _LEGACY_ERROR_CATEGORIES:
           error(filename, linenum, 'readability/nolint', 5,
                 'Unknown NOLINT error category: %s' % category)

--- a/ament_cpplint/ament_cpplint/cpplint.py
+++ b/ament_cpplint/ament_cpplint/cpplint.py
@@ -614,7 +614,7 @@ def ParseNolintSuppressions(filename, raw_line, linenum, error):
         category = category[1:-1]
         if category in _ERROR_CATEGORIES:
           _error_suppressions.setdefault(category, set()).add(suppressed_line)
-        elif any([c for c in _OTHER_NOLINT_CATEGORY_PREFIXES if category.startswith(c)]):
+        elif any(c for c in _OTHER_NOLINT_CATEGORY_PREFIXES if category.startswith(c)):
           # Ignore any categories from other tools.
           pass
         elif category not in _LEGACY_ERROR_CATEGORIES:


### PR DESCRIPTION
So, I'm still running into issues with clang-tidy and cpplint colliding when using `NOLINT` comments. This is an idea on how to handle it and I've made an upstream issue to see what they think as well: https://github.com/cpplint/cpplint/issues/184

@nuclearsandwich @mjeronimo FYI