### PR TITLE
Disable cppcheck 2.x.

### DIFF
--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -122,8 +122,8 @@ def main(argv=sys.argv[1:]):
         # the number of cores cannot be determined, do not extend args
         pass
 
-    # detect cppcheck 1.88 which caused issues
-    if 'AMENT_CPPCHECK_ALLOW_1_88' not in os.environ:
+    # detect cppcheck 1.88 or 2.x which are much too slow
+    if 'AMENT_CPPCHECK_ALLOW_SLOW_VERSIONS' not in os.environ:
         if cppcheck_version == '1.88' or cppcheck_version.startswith('2.'):
             print(
                 f'cppcheck {cppcheck_version} has known performance issues and therefore will not '

--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -39,11 +39,15 @@ def find_cppcheck_executable():
 def get_cppcheck_version(cppcheck_bin):
     version_cmd = [cppcheck_bin, '--version']
     output = subprocess.check_output(version_cmd)
-    # expecting something like b'Cppcheck 1.88\n'
+    # expecting something like b'Cppcheck 1.88\n' or b'Cppcheck 2.7 dev'
     output = output.decode().strip()
     tokens = output.split()
-    if len(tokens) != 2:
+    if len(tokens) not in (2, 3):
         raise RuntimeError("unexpected cppcheck version string '{}'".format(output))
+
+    if tokens[0] != 'Cppcheck':
+        raise RuntimeError("unexpected cppcheck version name '{}'".format(output))
+
     return tokens[1]
 
 
@@ -120,10 +124,10 @@ def main(argv=sys.argv[1:]):
 
     # detect cppcheck 1.88 which caused issues
     if 'AMENT_CPPCHECK_ALLOW_1_88' not in os.environ:
-        if cppcheck_version == '1.88':
+        if cppcheck_version == '1.88' or cppcheck_version.startswith('2.'):
             print(
-                'cppcheck 1.88 has known performance issues and therefore will not be used, '
-                'set the AMENT_CPPCHECK_ALLOW_1_88 environment variable to override this.',
+                f'cppcheck {cppcheck_version} has known performance issues and therefore will not '
+                'be used, set the AMENT_CPPCHECK_ALLOW_1_88 environment variable to override this.',
                 file=sys.stderr,
             )
 
@@ -131,7 +135,7 @@ def main(argv=sys.argv[1:]):
                 report = {input_file: [] for input_file in files}
                 write_xunit_file(
                     args.xunit_file, report, time.time() - start_time,
-                    skip='cppcheck 1.88 performance issues'
+                    skip=f'cppcheck {cppcheck_version} performance issues'
                 )
                 return 0
 

--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -127,7 +127,7 @@ def main(argv=sys.argv[1:]):
         if cppcheck_version == '1.88' or cppcheck_version.startswith('2.'):
             print(
                 f'cppcheck {cppcheck_version} has known performance issues and therefore will not '
-                'be used, set the AMENT_CPPCHECK_ALLOW_1_88 environment variable to override this.',
+                'be used, set the AMENT_CPPCHECK_ALLOW_SLOW_VERSIONS environment variable to override this.',
                 file=sys.stderr,
             )
 


### PR DESCRIPTION
It has known performance issues (more than 10x slower than
cppcheck 1.9), so just get out early and don't run it.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>