### PR TITLE
Increase the ament_cmake_copyright default timeout.

### DIFF
--- a/ament_cmake_copyright/cmake/ament_copyright.cmake
+++ b/ament_cmake_copyright/cmake/ament_copyright.cmake
@@ -32,7 +32,7 @@ function(ament_copyright)
     set(ARG_TESTNAME "copyright")
   endif()
   if(NOT ARG_TIMEOUT)
-    set(ARG_TIMEOUT 120)
+    set(ARG_TIMEOUT 200)
   endif()
 
   find_program(ament_copyright_BIN NAMES "ament_copyright")


### PR DESCRIPTION
Add one minute so that Windows Debug won't fail as often.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

If you look at https://ci.ros2.org/view/nightly/job/nightly_win_deb/2282/consoleFull and search for:

```
C:/ci/ws/install/Scripts/ament_copyright.exe --xunit-file C:/ci/ws/build/rclcpp/test_results/rclcpp/copyright.xunit.xml
```

You'll see that the copyright check timed out.  If you look at an earlier job (like https://ci.ros2.org/view/nightly/job/nightly_win_deb/2277/consoleFull), and search for the same line, you'll see that the job completed in just under 120 seconds.  Since we are so close to the margin here, bump up the timeout to 200 seconds, which won't have an appreciable difference to our CI but should make it a lot more reliable on Windows Debug.