### PR TITLE
Improved licencse matching

### DIFF
--- a/ament_copyright/ament_copyright/parser.py
+++ b/ament_copyright/ament_copyright/parser.py
@@ -64,7 +64,8 @@ class FileDescriptor:
             for template in templates:
                 formatted_template = remove_formatting(template)
                 last_index = -1
-                for license_section in formatted_template.split('{copyright_holder}'):
+                template_sections = split_template(formatted_template, ['{copyright_holder}', '{copyright}'])
+                for license_section in template_sections:
                     # OK, now look for each section of the license in the incoming
                     # content.
                     index = remove_formatting(content).find(license_section.strip())
@@ -286,3 +287,14 @@ def is_empty_line(content, index):
 
 def remove_formatting(text):
     return ' '.join(filter(None, text.split()))
+
+# Flat list of sections split on all separators provided
+def split_template(sections, separators):
+    if type(sections) != list:
+        return split_template([sections], separators)
+    elif len(separators) > 1:
+        return sum([split_template([section], separators[0:1]) for section
+                    in sum([split_template([section], separators[1:]) for section in sections], [])], [])
+    else:
+        return list(filter(lambda s: len(s) > 0,
+            sum([section.split(separators[0]) for section in sections], [])))

--- a/ament_copyright/ament_copyright/parser.py
+++ b/ament_copyright/ament_copyright/parser.py
@@ -65,7 +65,8 @@ class FileDescriptor:
             for template in templates:
                 last_index = -1
                 formatted_template = remove_formatting(template)
-                template_sections = split_template(formatted_template, ['{copyright_holder}', '{copyright}'])
+                template_sections = split_template(formatted_template,
+                                                   ['{copyright_holder}', '{copyright}'])
                 for license_section in template_sections:
                     # OK, now look for each section of the license in the incoming
                     # content.
@@ -289,13 +290,15 @@ def is_empty_line(content, index):
 def remove_formatting(text):
     return ' '.join(filter(None, text.split()))
 
+
 # Flat list of sections split on all separators provided
 def split_template(sections, separators):
     if type(sections) != list:
         return split_template([sections], separators)
     elif len(separators) > 1:
         return sum([split_template([section], separators[0:1]) for section
-                    in sum([split_template([section], separators[1:]) for section in sections], [])], [])
+                    in sum([split_template([section], separators[1:])
+                            for section in sections], [])], [])
     else:
         return list(filter(lambda s: len(s) > 0,
-            sum([section.split(separators[0]) for section in sections], [])))
+                           sum([section.split(separators[0]) for section in sections], [])))

--- a/ament_copyright/ament_copyright/parser.py
+++ b/ament_copyright/ament_copyright/parser.py
@@ -55,12 +55,14 @@ class FileDescriptor:
     def parse(self):
         raise NotImplementedError()
 
-    def identify_license(self, content, license_part):
+    def identify_license(self, content, license_part, licenses=None):
         if content is None:
             return
+        if licenses is None:
+            licenses = get_licenses()
         formatted_content = remove_formatting(content)
 
-        for name, license_ in get_licenses().items():
+        for name, license_ in licenses.items():
             templates = getattr(license_, license_part)
             for template in templates:
                 last_index = -1

--- a/ament_copyright/ament_copyright/parser.py
+++ b/ament_copyright/ament_copyright/parser.py
@@ -58,17 +58,18 @@ class FileDescriptor:
     def identify_license(self, content, license_part):
         if content is None:
             return
+        formatted_content = remove_formatting(content)
 
         for name, license_ in get_licenses().items():
             templates = getattr(license_, license_part)
             for template in templates:
-                formatted_template = remove_formatting(template)
                 last_index = -1
+                formatted_template = remove_formatting(template)
                 template_sections = split_template(formatted_template, ['{copyright_holder}', '{copyright}'])
                 for license_section in template_sections:
                     # OK, now look for each section of the license in the incoming
                     # content.
-                    index = remove_formatting(content).find(license_section.strip())
+                    index = formatted_content.find(license_section.strip())
                     if index == -1 or index <= last_index:
                         # Some part of the license is not in the content, or the license
                         # is rearranged, this license doesn't match.

--- a/ament_copyright/test/test_parser.py
+++ b/ament_copyright/test/test_parser.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ament_copyright.parser import search_copyright_information
+from ament_copyright.parser import search_copyright_information, split_template
 
 
 def test_search_copyright_information_incorrect_typo():
@@ -124,3 +124,21 @@ def test_search_copyright_information_uppercase2():
     copyrights, remaining_block = search_copyright_information(
         'COPYRIGHT (C) 2020 Open Source Robotics Foundation, Inc.')
     assert len(copyrights) == 1
+
+
+def test_split_template_no_split():
+    content = '1 2 3'
+    sections = split_template(content, 'A')
+    assert len(sections) == 1
+
+
+def test_split_template_single_split():
+    content = '1 A 2'
+    sections = split_template(content, 'A')
+    assert len(sections) == 2
+
+
+def test_split_template_multiple_splits():
+    content = '1 A 2 B 3 A 4 C 5 B 6'
+    sections = split_template(content, ['A', 'B', 'C'])
+    assert len(sections) == 6


### PR DESCRIPTION
I am using the approach described in https://answers.ros.org/question/343351/whats-the-proper-way-to-use-a-proprietary-software-license-according-to-ament_copyright/?answer=343355#post-id-343355 to add a proprietary license for my organization that can be enforced with `ament_copyright`. One issue I am running into is that the license header has multiple references to a copyright statement so the current license matching fails.

I would like to update the license matching to split the license header into sections separated by `{copyright_holder}` or `{copyright}`. The current matching only splits into sections by `{coyright_holder}`.

Here is an abbreviated example of the license header template I need this to work with:
```
 {copyright}
 ALL RIGHTS RESERVED
 
 
 THIS UNPUBLISHED WORK BY {copyright_holder} IS PROTECTED. IF PUBLICATION OF THE WORK SHOULD
 OCCUR, THE FOLLOWING NOTICE SHALL APPLY.
 
  "{copyright} ALL RIGHTS RESERVED."
 
 {copyright_holder} DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE.
```