### PR TITLE
Updated regex and adding test cases for copyright search

### DIFF
--- a/ament_copyright/ament_copyright/parser.py
+++ b/ament_copyright/ament_copyright/parser.py
@@ -178,7 +178,8 @@ def search_copyright_information(content):
     year_range = '%s-%s' % (year, year)
     year_or_year_range = '(?:%s|%s)' % (year, year_range)
     pattern = r'^[^\n\r]?\s*(?:\\copyright\s*)?' \
-              r'Copyright(?:\s+\(c\))?\s+(%s(?:,\s*%s)*),?\s+([^\n\r]+)$' % \
+              r'(?:Copyright|COPYRIGHT|copyright)' \
+              r'(?:\s+\((?:c|C)\))?\s+(%s(?:,\s*%s)*),?\s+([^\n\r]+)$' % \
         (year_or_year_range, year_or_year_range)
     regex = re.compile(pattern, re.DOTALL | re.MULTILINE)
 

--- a/ament_copyright/ament_copyright/parser.py
+++ b/ament_copyright/ament_copyright/parser.py
@@ -178,9 +178,9 @@ def search_copyright_information(content):
     year_range = '%s-%s' % (year, year)
     year_or_year_range = '(?:%s|%s)' % (year, year_range)
     pattern = r'^[^\n\r]?\s*(?:\\copyright\s*)?' \
-              r'Copyright(?:\s+\(c\))?\s+(%s(?:,\s*%s)*),?\s+([^\n\r]+)$' % \
+              r'copyright(?:\s+\(c\))?\s+(%s(?:,\s*%s)*),?\s+([^\n\r]+)$' % \
         (year_or_year_range, year_or_year_range)
-    regex = re.compile(pattern, re.DOTALL | re.MULTILINE)
+    regex = re.compile(pattern, re.DOTALL | re.MULTILINE | re.IGNORECASE)
 
     copyrights = []
     while True:

--- a/ament_copyright/ament_copyright/parser.py
+++ b/ament_copyright/ament_copyright/parser.py
@@ -178,8 +178,7 @@ def search_copyright_information(content):
     year_range = '%s-%s' % (year, year)
     year_or_year_range = '(?:%s|%s)' % (year, year_range)
     pattern = r'^[^\n\r]?\s*(?:\\copyright\s*)?' \
-              r'(?:Copyright|COPYRIGHT|copyright)' \
-              r'(?:\s+\((?:c|C)\))?\s+(%s(?:,\s*%s)*),?\s+([^\n\r]+)$' % \
+              r'Copyright(?:\s+\(c\))?\s+(%s(?:,\s*%s)*),?\s+([^\n\r]+)$' % \
         (year_or_year_range, year_or_year_range)
     regex = re.compile(pattern, re.DOTALL | re.MULTILINE)
 

--- a/ament_copyright/test/test_parser.py
+++ b/ament_copyright/test/test_parser.py
@@ -15,7 +15,7 @@
 from ament_copyright.parser import search_copyright_information
 
 
-def test_search_copyright_information_incorrect():
+def test_search_copyright_information_incorrect_typo():
     """Test searching for copyright information with a typo in the copyright information."""
     copyrights, remaining_block = search_copyright_information(
         'CopyrightTypo 2020 Open Source Robotics Foundation, Inc.'
@@ -23,15 +23,25 @@ def test_search_copyright_information_incorrect():
     assert len(copyrights) == 0
 
 
+def test_search_copyright_information_repeated():
+    """Test searching with repeated 'copyright' in the copyright information."""
+    copyrights, remaining_block = search_copyright_information(
+        '\\copyright Copyright 2020 Open Source Robotics Foundation, Inc.'
+    )
+    assert len(copyrights) > 0
+
+
 def test_search_copyright_information_capitalization1():
     """
     Test searching for copyright information with capitalized copyright information.
 
     Word 'copyright': capitalized
-    Abbreviation '(c)': present and lowercase
+    Abbreviation '(c)': absent
     """
     copyrights, remaining_block = search_copyright_information(
-        'Copyright 2020 Open Source Robotics Foundation, Inc.')
+        '  Copyright 2020 Open Source Robotics Foundation, Inc.')
+    print(copyrights[0].name)
+    assert copyrights[0].name == 'Open Source Robotics Foundation, Inc.'
     assert len(copyrights) > 0
 
 
@@ -40,7 +50,7 @@ def test_search_copyright_information_capitalization2():
     Test searching for copyright information with capitalized copyright information.
 
     Word 'copyright': capitalized
-    Abbrebiation '(c)': present and lowercase
+    Abbreviation '(c)': lowercase
     """
     copyrights, remaining_block = search_copyright_information(
         'Copyright (c) 2020 Open Source Robotics Foundation, Inc.')
@@ -52,7 +62,7 @@ def test_search_copyright_information_capitalization3():
     Test searching for copyright information with capitalized copyright information.
 
     Word 'copyright': capitalized
-    Abbrebiation '(c)': present and uppercase
+    Abbreviation '(c)': uppercase
     """
     copyrights, remaining_block = search_copyright_information(
         'Copyright (C) 2020 Open Source Robotics Foundation, Inc.')
@@ -64,7 +74,7 @@ def test_search_copyright_information_lowercase1():
     Test searching for copyright information with lowercase copyright information.
 
     Word 'copyright': lowercase
-    Abbrebiation '(c)': absent
+    Abbreviation '(c)': absent
     """
     copyrights, remaining_block = search_copyright_information(
         'copyright 2020 Open Source Robotics Foundation, Inc.')
@@ -76,8 +86,32 @@ def test_search_copyright_information_lowercase2():
     Test searching for copyright information with lowercase copyright information and abbreviation.
 
     Word 'copyright': lowercase
-    Abbrebiation '(c)': lowercase
+    Abbreviation '(c)': lowercase
     """
     copyrights, remaining_block = search_copyright_information(
         'copyright (c) 2020 Open Source Robotics Foundation, Inc.')
+    assert len(copyrights) > 0
+
+
+def test_search_copyright_information_uppercase1():
+    """
+    Test searching for copyright information with uppercase copyright information.
+
+    Word 'copyright': uppercase
+    Abbreviation '(c)': absent
+    """
+    copyrights, remaining_block = search_copyright_information(
+        'COPYRIGHT 2020 Open Source Robotics Foundation, Inc.')
+    assert len(copyrights) > 0
+
+
+def test_search_copyright_information_uppercase2():
+    """
+    Test searching for copyright information with uppercase copyright information.
+
+    Word 'copyright': uppercase
+    Abbreviation '(c)': uppercase
+    """
+    copyrights, remaining_block = search_copyright_information(
+        'COPYRIGHT (C) 2020 Open Source Robotics Foundation, Inc.')
     assert len(copyrights) > 0

--- a/ament_copyright/test/test_parser.py
+++ b/ament_copyright/test/test_parser.py
@@ -31,6 +31,15 @@ def test_search_copyright_information_repeated():
     assert len(copyrights) == 1
 
 
+def test_search_copyright_information_multiple_holders():
+    """Test searching multiple holders."""
+    copyrights, remaining_block = search_copyright_information(
+        """Copyright 2020 Open Source Robotics Foundation, Inc.
+           Copyright (c) 2009, Willow Garage, Inc."""
+    )
+    assert len(copyrights) == 2
+
+
 def test_search_copyright_information_capitalization1():
     """
     Test searching for copyright information with capitalized copyright information.

--- a/ament_copyright/test/test_parser.py
+++ b/ament_copyright/test/test_parser.py
@@ -1,0 +1,83 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_copyright.parser import search_copyright_information
+
+
+def test_search_copyright_information_incorrect():
+    """Test searching for copyright information with a typo in the copyright information."""
+    copyrights, remaining_block = search_copyright_information(
+        'CopyrightTypo 2020 Open Source Robotics Foundation, Inc.'
+    )
+    assert len(copyrights) == 0
+
+
+def test_search_copyright_information_capitalization1():
+    """
+    Test searching for copyright information with capitalized copyright information.
+
+    Word 'copyright': capitalized
+    Abbreviation '(c)': present and lowercase
+    """
+    copyrights, remaining_block = search_copyright_information(
+        'Copyright 2020 Open Source Robotics Foundation, Inc.')
+    assert len(copyrights) > 0
+
+
+def test_search_copyright_information_capitalization2():
+    """
+    Test searching for copyright information with capitalized copyright information.
+
+    Word 'copyright': capitalized
+    Abbrebiation '(c)': present and lowercase
+    """
+    copyrights, remaining_block = search_copyright_information(
+        'Copyright (c) 2020 Open Source Robotics Foundation, Inc.')
+    assert len(copyrights) > 0
+
+
+def test_search_copyright_information_capitalization3():
+    """
+    Test searching for copyright information with capitalized copyright information.
+
+    Word 'copyright': capitalized
+    Abbrebiation '(c)': present and uppercase
+    """
+    copyrights, remaining_block = search_copyright_information(
+        'Copyright (C) 2020 Open Source Robotics Foundation, Inc.')
+    assert len(copyrights) > 0
+
+
+def test_search_copyright_information_lowercase1():
+    """
+    Test searching for copyright information with lowercase copyright information.
+
+    Word 'copyright': lowercase
+    Abbrebiation '(c)': absent
+    """
+    copyrights, remaining_block = search_copyright_information(
+        'copyright 2020 Open Source Robotics Foundation, Inc.')
+    assert len(copyrights) > 0
+
+
+def test_search_copyright_information_lowercase2():
+    """
+    Test searching for copyright information with lowercase copyright information and abbreviation.
+
+    Word 'copyright': lowercase
+    Abbrebiation '(c)': lowercase
+    """
+    copyrights, remaining_block = search_copyright_information(
+        'copyright (c) 2020 Open Source Robotics Foundation, Inc.')
+    assert len(copyrights) > 0

--- a/ament_copyright/test/test_parser.py
+++ b/ament_copyright/test/test_parser.py
@@ -28,7 +28,7 @@ def test_search_copyright_information_repeated():
     copyrights, remaining_block = search_copyright_information(
         '\\copyright Copyright 2020 Open Source Robotics Foundation, Inc.'
     )
-    assert len(copyrights) > 0
+    assert len(copyrights) == 1
 
 
 def test_search_copyright_information_capitalization1():
@@ -42,7 +42,7 @@ def test_search_copyright_information_capitalization1():
         '  Copyright 2020 Open Source Robotics Foundation, Inc.')
     print(copyrights[0].name)
     assert copyrights[0].name == 'Open Source Robotics Foundation, Inc.'
-    assert len(copyrights) > 0
+    assert len(copyrights) == 1
 
 
 def test_search_copyright_information_capitalization2():
@@ -54,7 +54,7 @@ def test_search_copyright_information_capitalization2():
     """
     copyrights, remaining_block = search_copyright_information(
         'Copyright (c) 2020 Open Source Robotics Foundation, Inc.')
-    assert len(copyrights) > 0
+    assert len(copyrights) == 1
 
 
 def test_search_copyright_information_capitalization3():
@@ -66,7 +66,7 @@ def test_search_copyright_information_capitalization3():
     """
     copyrights, remaining_block = search_copyright_information(
         'Copyright (C) 2020 Open Source Robotics Foundation, Inc.')
-    assert len(copyrights) > 0
+    assert len(copyrights) == 1
 
 
 def test_search_copyright_information_lowercase1():
@@ -78,7 +78,7 @@ def test_search_copyright_information_lowercase1():
     """
     copyrights, remaining_block = search_copyright_information(
         'copyright 2020 Open Source Robotics Foundation, Inc.')
-    assert len(copyrights) > 0
+    assert len(copyrights) == 1
 
 
 def test_search_copyright_information_lowercase2():
@@ -90,7 +90,7 @@ def test_search_copyright_information_lowercase2():
     """
     copyrights, remaining_block = search_copyright_information(
         'copyright (c) 2020 Open Source Robotics Foundation, Inc.')
-    assert len(copyrights) > 0
+    assert len(copyrights) == 1
 
 
 def test_search_copyright_information_uppercase1():
@@ -102,7 +102,7 @@ def test_search_copyright_information_uppercase1():
     """
     copyrights, remaining_block = search_copyright_information(
         'COPYRIGHT 2020 Open Source Robotics Foundation, Inc.')
-    assert len(copyrights) > 0
+    assert len(copyrights) == 1
 
 
 def test_search_copyright_information_uppercase2():
@@ -114,4 +114,4 @@ def test_search_copyright_information_uppercase2():
     """
     copyrights, remaining_block = search_copyright_information(
         'COPYRIGHT (C) 2020 Open Source Robotics Foundation, Inc.')
-    assert len(copyrights) > 0
+    assert len(copyrights) == 1


### PR DESCRIPTION
This branch updates the copyright search to support different forms of capitalization and adds tests cases for different combinations of capitalization. See discussion at: https://github.com/ament/ament_lint/issues/359