### PR TITLE
Fix importlib_metadata warning on Python 3.10.

### DIFF
--- a/ament_copyright/ament_copyright/__init__.py
+++ b/ament_copyright/ament_copyright/__init__.py
@@ -38,7 +38,12 @@ UNKNOWN_IDENTIFIER = '<unknown>'
 
 def get_copyright_names():
     names = {}
-    for entry_point in importlib_metadata.entry_points().get(COPYRIGHT_GROUP, []):
+    entry_points = importlib_metadata.entry_points()
+    if hasattr(entry_points, 'select'):
+        copyright_groups = entry_points.select(group=COPYRIGHT_GROUP)
+    else:
+        copyright_groups = entry_points.get(COPYRIGHT_GROUP, [])
+    for entry_point in copyright_groups:
         assert entry_point.name != UNKNOWN_IDENTIFIER, \
             "Invalid entry point name '%s'" % entry_point.name
         name = entry_point.load()
@@ -48,7 +53,12 @@ def get_copyright_names():
 
 def get_licenses():
     licenses = {}
-    for entry_point in importlib_metadata.entry_points().get(LICENSE_GROUP, []):
+    entry_points = importlib_metadata.entry_points()
+    if hasattr(entry_points, 'select'):
+        license_groups = entry_points.select(group=LICENSE_GROUP)
+    else:
+        license_groups = entry_points.get(LICENSE_GROUP, [])
+    for entry_point in license_groups:
         assert entry_point.name != UNKNOWN_IDENTIFIER, \
             "Invalid entry point name '%s'" % entry_point.name
         licenses[entry_point.name] = entry_point.load()


### PR DESCRIPTION
This makes it use the newer select interface when available,
but fallback to the dict interface as needed.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Connects to https://github.com/ros2/ros2/issues/1254