### PR TITLE
[Galactic] [ament_cmake_cppcheck] Fix file exclusion behavior (#329)

### DIFF
--- a/ament_cmake_cppcheck/cmake/ament_cppcheck.cmake
+++ b/ament_cmake_cppcheck/cmake/ament_cppcheck.cmake
@@ -33,7 +33,7 @@
 # @public
 #
 function(ament_cppcheck)
-  cmake_parse_arguments(ARG "" "EXCLUDE;LANGUAGE;TESTNAME" "INCLUDE_DIRS" ${ARGN})
+  cmake_parse_arguments(ARG "" "LANGUAGE;TESTNAME" "EXCLUDE;INCLUDE_DIRS" ${ARGN})
   if(NOT ARG_TESTNAME)
     set(ARG_TESTNAME "cppcheck")
   endif()


### PR DESCRIPTION
This PR backports #329 to Galactic.

---

The `EXCLUDE` argument of the `ament_cppcheck` CMake function is
a list, i.e. a multi-value keyword. As such, it needs to be placed
out of the one-value keywords from the `cmake_parse_arguments`
function call.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>
(cherry picked from commit fd2feb1e369cd24181b661698190bfcd1b4ab199)