### PR TITLE
recommend use of --mixin compile-commands

### DIFF
--- a/ament_clang_tidy/doc/index.rst
+++ b/ament_clang_tidy/doc/index.rst
@@ -12,7 +12,7 @@ How to run the check from the command line?
 
 *Prerequisites*: ``clang-tidy-6.0``, ``clang-tools-6.0``, and ``python-yaml`` packages should
 have already been installed. ``compile_commands.json`` files should have already been generated
-(e.g.: workspace built with ``colcon build --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON``).
+(e.g.: workspace built with ``colcon build --mixin compile-commands``).
 
 .. code:: sh
 


### PR DESCRIPTION
Kind of a follow up of https://github.com/ament/ament_lint/pull/287, as the `--packages-select` option only makes sense with a combined `compile_commands.json` in the build folder, which you only get with this mixin because it aggregates them for you there. Otherwise each package would generate its own `compile_commands.json` file.