### PR TITLE
Consider files with '.hh' extension as C++ headers

### DIFF
--- a/ament_cpplint/ament_cpplint/cpplint.py
+++ b/ament_cpplint/ament_cpplint/cpplint.py
@@ -5017,7 +5017,8 @@ def _ClassifyInclude(fileinfo, include, used_angle_brackets, include_order="defa
             or Search(r'(?:%s)\/.*\.h' % "|".join(C_STANDARD_HEADER_FOLDERS), include))
 
   # Headers with C++ extensions shouldn't be considered C system headers
-  is_system = used_angle_brackets and not os.path.splitext(include)[1] in ['.hpp', '.hxx', '.h++']
+  include_ext = os.path.splitext(include)[1]
+  is_system = used_angle_brackets and not include_ext in ['.hh', '.hpp', '.hxx', '.h++']
 
   if is_system:
     if is_cpp_header:


### PR DESCRIPTION
Without this change, these files are considered to be C system headers.
This change affects the expected include order with respect to '.hh' files.

---

I ran across this since Gazebo uses the .hh extension for C++ headers.

If this change is acceptable, then I'll check for any instances across the ROS 2 core packages and propose a fix [upstream](https://github.com/cpplint/cpplint).