### PR TITLE
Enable SARIF output for Space ROS testing

### DIFF
--- a/ament_cmake_clang_format/cmake/ament_clang_format.cmake
+++ b/ament_cmake_clang_format/cmake/ament_clang_format.cmake
@@ -44,8 +44,9 @@ function(ament_clang_format)
     message(FATAL_ERROR "ament_clang_format() variable 'ament_clang_format_BIN' must not be empty")
   endif()
 
-  set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.xunit.xml")
-  set(cmd "${ament_clang_format_BIN}" "--xunit-file" "${result_file}")
+  set(xunit_result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.xunit.xml")
+  set(sarif_result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.sarif")
+  set(cmd "${ament_clang_format_BIN}" "--xunit-file" "${xunit_result_file}" "--sarif-file" "${sarif_result_file}")
   list(APPEND cmd ${ARG_UNPARSED_ARGUMENTS})
   if(ARG_CONFIG_FILE)
     list(APPEND cmd "--config" "${ARG_CONFIG_FILE}")
@@ -58,7 +59,7 @@ function(ament_clang_format)
     "${ARG_TESTNAME}"
     COMMAND ${cmd}
     OUTPUT_FILE "${CMAKE_BINARY_DIR}/ament_clang_format/${ARG_TESTNAME}.txt"
-    RESULT_FILE "${result_file}"
+    RESULT_FILE "${xunit_result_file}"
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
   )
   set_tests_properties(

--- a/ament_cmake_clang_tidy/cmake/ament_clang_tidy.cmake
+++ b/ament_cmake_clang_tidy/cmake/ament_clang_tidy.cmake
@@ -45,8 +45,9 @@ function(ament_clang_tidy)
     message(FATAL_ERROR "ament_clang_tidy() variable 'ament_clang_tidy_BIN' must not be empty")
   endif()
 
-  set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.xunit.xml")
-  set(cmd "${ament_clang_tidy_BIN}" "--xunit-file" "${result_file}")
+  set(xunit_result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.xunit.xml")
+  set(sarif_result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.sarif")
+  set(cmd "${ament_clang_tidy_BIN}" "--xunit-file" "${xunit_result_file}" "--sarif-file" "${sarif_result_file}")
   list(APPEND cmd ${ARG_UNPARSED_ARGUMENTS})
 
   if(ARG_CONFIG_FILE)
@@ -64,7 +65,7 @@ function(ament_clang_tidy)
     "${ARG_TESTNAME}"
     COMMAND ${cmd}
     OUTPUT_FILE "${CMAKE_BINARY_DIR}/ament_clang_tidy/${ARG_TESTNAME}.txt"
-    RESULT_FILE "${result_file}"
+    RESULT_FILE "${xunit_result_file}"
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     TIMEOUT "${ARG_TIMEOUT}"
   )

--- a/ament_cmake_copyright/cmake/ament_copyright.cmake
+++ b/ament_cmake_copyright/cmake/ament_copyright.cmake
@@ -38,8 +38,9 @@ function(ament_copyright)
     message(FATAL_ERROR "ament_copyright() could not find program 'ament_copyright'")
   endif()
 
-  set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.xunit.xml")
-  set(cmd "${ament_copyright_BIN}" "--xunit-file" "${result_file}")
+  set(xunit_result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.xunit.xml")
+  set(sarif_result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.sarif")
+  set(cmd "${ament_copyright_BIN}" "--xunit-file" "${xunit_result_file}" "--sarif-file" "${sarif_result_file}")
   list(APPEND cmd ${ARG_UNPARSED_ARGUMENTS})
 
   file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/ament_copyright")
@@ -47,7 +48,7 @@ function(ament_copyright)
     "${ARG_TESTNAME}"
     COMMAND ${cmd}
     OUTPUT_FILE "${CMAKE_BINARY_DIR}/ament_copyright/${ARG_TESTNAME}.txt"
-    RESULT_FILE "${result_file}"
+    RESULT_FILE "${xunit_result_file}"
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     TIMEOUT "${ARG_TIMEOUT}"
   )

--- a/ament_cmake_cppcheck/cmake/ament_cppcheck.cmake
+++ b/ament_cmake_cppcheck/cmake/ament_cppcheck.cmake
@@ -45,8 +45,9 @@ function(ament_cppcheck)
     message(FATAL_ERROR "ament_cppcheck() could not find program 'ament_cppcheck'")
   endif()
 
-  set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.xunit.xml")
-  set(cmd "${ament_cppcheck_BIN}" "--xunit-file" "${result_file}")
+  set(xunit_result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.xunit.xml")
+  set(sarif_result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.sarif")
+  set(cmd "${ament_cppcheck_BIN}" "--xunit-file" "${xunit_result_file}" "--sarif-file" "${sarif_result_file}")
   list(APPEND cmd ${ARG_UNPARSED_ARGUMENTS})
   if(ARG_EXCLUDE)
     list(APPEND cmd "--exclude" "${ARG_EXCLUDE}")
@@ -68,7 +69,7 @@ function(ament_cppcheck)
     COMMAND ${cmd}
     TIMEOUT 300
     OUTPUT_FILE "${CMAKE_BINARY_DIR}/ament_cppcheck/${ARG_TESTNAME}.txt"
-    RESULT_FILE "${result_file}"
+    RESULT_FILE "${xunit_result_file}"
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
   )
   set_tests_properties(

--- a/ament_cmake_cpplint/cmake/ament_cpplint.cmake
+++ b/ament_cmake_cpplint/cmake/ament_cpplint.cmake
@@ -44,8 +44,9 @@ function(ament_cpplint)
     message(FATAL_ERROR "ament_cpplint() could not find program 'ament_cpplint'")
   endif()
 
-  set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.xunit.xml")
-  set(cmd "${ament_cpplint_BIN}" "--xunit-file" "${result_file}")
+  set(xunit_result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.xunit.xml")
+  set(sarif_result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.sarif")
+  set(cmd "${ament_cpplint_BIN}" "--xunit-file" "${xunit_result_file}" "--sarif-file" "${sarif_result_file}")
   if(ARG_EXCLUDE)
     list(APPEND cmd "--exclude" "${ARG_EXCLUDE}")
   endif()
@@ -69,7 +70,7 @@ function(ament_cpplint)
     "${ARG_TESTNAME}"
     COMMAND ${cmd}
     OUTPUT_FILE "${CMAKE_BINARY_DIR}/ament_cpplint/${ARG_TESTNAME}.txt"
-    RESULT_FILE "${result_file}"
+    RESULT_FILE "${xunit_result_file}"
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     TIMEOUT "${ARG_TIMEOUT}"
   )

--- a/ament_cmake_uncrustify/cmake/ament_uncrustify.cmake
+++ b/ament_cmake_uncrustify/cmake/ament_uncrustify.cmake
@@ -47,8 +47,9 @@ function(ament_uncrustify)
     message(FATAL_ERROR "ament_uncrustify() could not find program 'ament_uncrustify'")
   endif()
 
-  set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.xunit.xml")
-  set(cmd "${ament_uncrustify_BIN}" "--xunit-file" "${result_file}")
+  set(xunit_result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.xunit.xml")
+  set(sarif_result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.sarif")
+  set(cmd "${ament_uncrustify_BIN}" "--xunit-file" "${xunit_result_file}" "--sarif-file" "${sarif_result_file}")
   if(DEFINED ARG_MAX_LINE_LENGTH)
     list(APPEND cmd "--linelength" "${ARG_MAX_LINE_LENGTH}")
   endif()
@@ -66,7 +67,7 @@ function(ament_uncrustify)
     "${ARG_TESTNAME}"
     COMMAND ${cmd}
     OUTPUT_FILE "${CMAKE_BINARY_DIR}/ament_uncrustify/${ARG_TESTNAME}.txt"
-    RESULT_FILE "${result_file}"
+    RESULT_FILE "${xunit_result_file}"
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
   )
   set_tests_properties(

--- a/ament_copyright/ament_copyright/main.py
+++ b/ament_copyright/ament_copyright/main.py
@@ -100,7 +100,7 @@ def main(argv=sys.argv[1:]):
     # such that --xunit-file and --sarif-file options can be used together, but are still part of
     # the mutually exclusive group. For example: XOR(A, B, C, D, (E OR F)).
     if any([
-            args.add_missing, args.add_copyright_year != None,
+            args.add_missing, args.add_copyright_year is not None,
             args.list_copyright_names, args.list_licenses
     ]) and args.sarif_file:
         # Emulate the output normally produced by argparse
@@ -110,7 +110,9 @@ def main(argv=sys.argv[1:]):
             end='')
         if args.add_missing:
             print('--add-missing')
-        elif args.add_copyright_year:
+        # The empty list is considered false, so we have to account for the user specifying --add-copyright-year
+        # without specifying a year (meaning use the current year), which results in an empty list.
+        elif args.add_copyright_year is not None:
             print('--add-copyright-year')
         elif args.list_copyright_names:
             print('--list-copyright-names')

--- a/ament_copyright/ament_copyright/main.py
+++ b/ament_copyright/ament_copyright/main.py
@@ -91,10 +91,33 @@ def main(argv=sys.argv[1:]):
     group.add_argument(
         '--xunit-file',
         help='Generate a xunit compliant XML file')
-    group.add_argument(
+    parser.add_argument(
         '--sarif-file',
         help='Generate a SARIF file')
     args = parser.parse_args(argv)
+
+    # Have to do some additional argument testing here because argparse doesn't support nested groups,
+    # such that --xunit-file and --sarif-file options can be used together, but are still part of
+    # the mutually exclusive group. For example: XOR(A, B, C, D, (E OR F)).
+    if any([
+            args.add_missing, args.add_copyright_year != None,
+            args.list_copyright_names, args.list_licenses
+    ]) and args.sarif_file:
+        # Emulate the output normally produced by argparse
+        parser.print_usage()
+        print(
+            f'{os.path.basename(__file__)}: error: argument --sarif-file: not allowed with argument ',
+            end='')
+        if args.add_missing:
+            print('--add-missing')
+        elif args.add_copyright_year:
+            print('--add-copyright-year')
+        elif args.list_copyright_names:
+            print('--list-copyright-names')
+        elif args.list_licenses:
+            print('--list-licenses')
+        print()
+        return -1
 
     names = get_copyright_names()
     if args.list_copyright_names:


### PR DESCRIPTION
Add the --sarif-file command-line option to the invocation of all of the static analysis tools (via colcon test).

Also, ament_copyright requires some special handling because it has some mutually exclusive options, but --sarif-file and --xunit-file should both be allowed during the same run. 

Fixes: https://github.com/space-ros/space-ros/issues/41

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>