### PR TITLE
[ament_cpplint] Process errors without linenums

### DIFF
--- a/ament_cpplint/ament_cpplint/main.py
+++ b/ament_cpplint/ament_cpplint/main.py
@@ -305,11 +305,12 @@ def get_xunit_content(report, testname, elapsed):
         if errors:
             # report each cpplint error as a failing testcase
             for error in errors:
+                linenum = str(error['linenum']) if error['linenum'] is not None else 'None'
                 data = {
                     'quoted_name': quoteattr(
-                        '%s [%s] (%s:%d)' % (
+                        '%s [%s] (%s:%s)' % (
                             error['category'], error['confidence'],
-                            filename, error['linenum'])),
+                            filename, linenum)),
                     'testname': testname,
                     'quoted_message': quoteattr(error['message']),
                 }


### PR DESCRIPTION
It is possible for cpplint to output errors that do not have an
associated line number. The xunit file generation process throws a
TypeError when dealing with such errors since it strictly expects an
integral value for the line number (and not a NoneType).

This commit lets ament_cpplint process errors without line numbers,
replacing the integral line number value with 'None' in the output xunit
file when it is appropriate to do so.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>

---

Here's a simple demonstration of an error without line numbers (2nd error):

```bash
$ mkdir -p /tmp/cpplint_nolinenum && cd /tmp/cpplint_nolinenum
$ touch test.hpp test.cpp
$ ament_cpplint --xunit-file test.xml
Using '--root=/tmp/cpplint_nolinenum' argument

/tmp/cpplint_nolinenum/test.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
/tmp/cpplint_nolinenum/test.cpp:None:  /tmp/cpplint_nolinenum/test.cpp should include its header file /tmp/cpplint_nolinenum/test.hpp  [build/include] [5]
Done processing /tmp/cpplint_nolinenum/test.cpp

/tmp/cpplint_nolinenum/test.hpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
/tmp/cpplint_nolinenum/test.hpp:0:  No #ifndef header guard found, suggested CPP variable is: TEST_HPP_  [build/header_guard] [5]
Done processing /tmp/cpplint_nolinenum/test.hpp

Category 'build/header_guard' errors found: 1
Category 'build/include' errors found: 1
Category 'legal/copyright' errors found: 2
Total errors found: 4
Traceback (most recent call last):
  File "/home/aprotyas/dev/workspaces/ament_ws/install/ament_cpplint/bin/ament_cpplint", line 33, in <module>
    sys.exit(load_entry_point('ament-cpplint', 'console_scripts', 'ament_cpplint')())
  File "/home/aprotyas/dev/workspaces/ament_ws/build/ament_cpplint/ament_cpplint/main.py", line 197, in main
    xml = get_xunit_content(report, testname, time.time() - start_time)
  File "/home/aprotyas/dev/workspaces/ament_ws/build/ament_cpplint/ament_cpplint/main.py", line 310, in get_xunit_content
    '%s [%s] (%s:%d)' % (
TypeError: %d format: a real number is required, not NoneType

```