### PR TITLE
[ament_lint_auto] General file exclusion with AMENT_LINT_AUTO_FILE_EXCLUDE

### DIFF
--- a/ament_cmake_copyright/cmake/ament_cmake_copyright_lint_hook.cmake
+++ b/ament_cmake_copyright/cmake/ament_cmake_copyright_lint_hook.cmake
@@ -15,4 +15,9 @@
 message(
   STATUS
   "Added test 'copyright' to check source files copyright and LICENSE")
-ament_copyright()
+
+if(DEFINED AMENT_LINT_AUTO_FILE_EXCLUDE)
+  ament_copyright(EXCLUDE ${AMENT_LINT_AUTO_FILE_EXCLUDE})
+else()
+  ament_copyright()
+endif()

--- a/ament_cmake_cppcheck/cmake/ament_cmake_cppcheck_lint_hook.cmake
+++ b/ament_cmake_cppcheck/cmake/ament_cmake_cppcheck_lint_hook.cmake
@@ -46,6 +46,10 @@ if(_source_files)
     list(APPEND _all_exclude ${ament_cmake_cppcheck_ADDITIONAL_EXCLUDE})
   endif()
 
+  if(DEFINED AMENT_LINT_AUTO_FILE_EXCLUDE)
+    list(APPEND _all_exclude ${AMENT_LINT_AUTO_FILE_EXCLUDE})
+  endif()
+
   # BUILDSYSTEM_TARGETS only supported in CMake >= 3.7
   if(NOT CMAKE_VERSION VERSION_LESS "3.7.0")
     get_directory_property(_build_targets DIRECTORY ${PROJECT_SOURCE_DIR} BUILDSYSTEM_TARGETS)

--- a/ament_cmake_cpplint/cmake/ament_cmake_cpplint_lint_hook.cmake
+++ b/ament_cmake_cpplint/cmake/ament_cmake_cpplint_lint_hook.cmake
@@ -31,6 +31,10 @@ if(_source_files)
     list(APPEND _all_exclude ${ament_cmake_cpplint_ADDITIONAL_EXCLUDE})
   endif()
 
+  if(DEFINED AMENT_LINT_AUTO_FILE_EXCLUDE)
+    list(APPEND _all_exclude ${AMENT_LINT_AUTO_FILE_EXCLUDE})
+  endif()
+
   message(STATUS "Configured cpplint exclude dirs and/or files: ${_all_exclude}")
   ament_cpplint(EXCLUDE ${_all_exclude})
 endif()

--- a/ament_cmake_uncrustify/cmake/ament_cmake_uncrustify_lint_hook.cmake
+++ b/ament_cmake_uncrustify/cmake/ament_cmake_uncrustify_lint_hook.cmake
@@ -30,6 +30,15 @@ if(_source_files)
     list(APPEND _args ${ament_cmake_uncrustify_ADDITIONAL_ARGS})
   endif()
 
+  set(_all_exclude "")
+  if(DEFINED ament_cmake_uncrustify_ADDITIONAL_EXCLUDE)
+    list(APPEND _all_exclude ${ament_cmake_uncrustify_ADDITIONAL_EXCLUDE})
+  endif()
+
+  if(DEFINED AMENT_LINT_AUTO_FILE_EXCLUDE)
+    list(APPEND _all_exclude ${AMENT_LINT_AUTO_FILE_EXCLUDE})
+  endif()
+
   message(STATUS "Configured uncrustify additional arguments: ${_args}")
-  ament_uncrustify(${_args})
+  ament_uncrustify(${_args} EXCLUDE ${_all_exclude})
 endif()

--- a/ament_lint_auto/doc/index.rst
+++ b/ament_lint_auto/doc/index.rst
@@ -43,3 +43,22 @@ sufficient to test with a set of common linters.
 The documentation of the package `ament_cmake_test
 <https://github.com/ament/ament_cmake>`_ provides more information on testing
 in CMake ament packages.
+
+How to exclude files with ament_lint_auto?
+------------------------------------------
+
+Linter hooks conform to the ament_lint_auto convention of excluding files
+specified in the CMake list variable `AMENT_LINT_AUTO_FILE_EXCLUDE`.
+As such, the CMake snippet from above can be modified to exclude files across
+all linters with one addition.
+
+``CMakeLists.txt``:
+
+.. code:: cmake
+
+    # this must happen before the invocation of ament_package()
+    if(BUILD_TESTING)
+      find_package(ament_lint_auto REQUIRED)
+      set(AMENT_LINT_AUTO_FILE_EXCLUDE /path/to/ignored_file ...)
+      ament_lint_auto_find_test_dependencies()
+    endif()


### PR DESCRIPTION
Currently, there is no interface to specify a file exclusion list for linters invoked through ament_lint_auto, and as such each linter needs to be provided with duplicates of a common file exclusion list.

As discussed in #343, it is reasonable to expect that linters registering themselves as ament_lint_auto extensions should abide to ament_lint_auto conventions in doing so. Namely, linter hooks should abide to the CMake list variable `AMENT_LINT_AUTO_FILE_EXCLUDE` which will propagate a file exclusion list to each linter invoked by ament_lint_auto.

Closes #343.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>