### PR TITLE
Fix exclude regression

### DIFF
--- a/ament_flake8/ament_flake8/main.py
+++ b/ament_flake8/ament_flake8/main.py
@@ -177,20 +177,23 @@ def get_flake8_style_guide(argv):
 def parse_config_file(config_file):
     from flake8.options import config, manager, aggregator
 
-    opts_manager = manager.OptionManager(prog='flake8', version='3.0.0')
-    flake8_options.register_default_options(opts_manager)
-
     try:
-        return aggregator.aggregate_options(
-            opts_manager,
-            config.ConfigFileFinder('flake8', [], [config_file]),
-            []
-        )
-    except TypeError:
         # Support 4.0.0
+        opts_manager = manager.OptionManager(prog='flake8', version='4.0.0')
+        flake8_options.register_default_options(opts_manager)
+
         return aggregator.aggregate_options(
             opts_manager,
             config.ConfigFileFinder('flake8', [], config_file),
+            []
+        )
+    except TypeError:
+        opts_manager = manager.OptionManager(prog='flake8', version='3.0.0')
+        flake8_options.register_default_options(opts_manager)
+
+        return aggregator.aggregate_options(
+            opts_manager,
+            config.ConfigFileFinder('flake8', [], [config_file]),
             []
         )
 

--- a/ament_flake8/ament_flake8/main.py
+++ b/ament_flake8/ament_flake8/main.py
@@ -180,11 +180,19 @@ def parse_config_file(config_file):
     opts_manager = manager.OptionManager(prog='flake8', version='3.0.0')
     flake8_options.register_default_options(opts_manager)
 
-    return aggregator.aggregate_options(
-        opts_manager,
-        config.ConfigFileFinder("flake8", [], [config_file]),
-        []
-    )
+    try:
+        return aggregator.aggregate_options(
+            opts_manager,
+            config.ConfigFileFinder('flake8', [], [config_file]),
+            []
+        )
+    except TypeError:
+        # Support 4.0.0
+        return aggregator.aggregate_options(
+            opts_manager,
+            config.ConfigFileFinder('flake8', [], config_file),
+            []
+        )
 
 
 def generate_flake8_report(config_file, paths, excludes, max_line_length=None):

--- a/ament_flake8/ament_flake8/main.py
+++ b/ament_flake8/ament_flake8/main.py
@@ -24,6 +24,7 @@ from xml.sax.saxutils import quoteattr
 import flake8
 from flake8.api.legacy import StyleGuide
 from flake8.main import application as flake8_app
+from flake8.main import options as flake8_options
 
 
 def main(argv=sys.argv[1:]):
@@ -173,7 +174,28 @@ def get_flake8_style_guide(argv):
     return StyleGuide(application)
 
 
+def parse_config_file(config_file):
+    from flake8.options import config, manager, aggregator
+
+    opts_manager = manager.OptionManager(prog='flake8', version='3.0.0')
+    flake8_options.register_default_options(opts_manager)
+
+    return aggregator.aggregate_options(
+        opts_manager,
+        config.ConfigFileFinder("flake8", [], [config_file]),
+        []
+    )
+
+
 def generate_flake8_report(config_file, paths, excludes, max_line_length=None):
+    opts, _ = parse_config_file(config_file)
+
+    # Ignore flake8 defaults here
+    if opts.exclude != list(flake8_options.defaults.EXCLUDE):
+        # Explicitly append to exclude args to prevent config excludes
+        # from being overwritten
+        excludes.extend(opts.exclude)
+
     flake8_argv = []
     if config_file is not None:
         flake8_argv.append('--config={0}'.format(config_file))


### PR DESCRIPTION
This PR fixes https://github.com/ament/ament_lint/issues/382 by explicitly adding any exclude args in the flake8 config file (normally `configuration/ament_flake8.ini`) to the exclude arglist.

Notably, this uses the same parsing logic that the version of flake8 ROS is using on focal and jammy (3.9.7 and 4.0.0).
I tried to account for differences in the parsing logic between 3.9.7 and 4.0.0 with a try except clause.