### PR TITLE
[ament_pep257][master] redirecting error prints to stderr

### DIFF
--- a/ament_pep257/ament_pep257/main.py
+++ b/ament_pep257/ament_pep257/main.py
@@ -131,7 +131,7 @@ def main(argv=sys.argv[1:]):
         print('No problems found')
         rc = 0
     else:
-        print('%d errors' % error_count)
+        print('%d errors' % error_count, file=sys.stderr)
         rc = 1
 
     # generate xunit file
@@ -211,21 +211,21 @@ def generate_pep257_report(paths, excludes, ignore, select, convention, add_igno
                 print(
                     '%s:%d %s: %s' %
                     (pep257_error.filename, pep257_error.line, pep257_error.definition,
-                     pep257_error.message))
+                     pep257_error.message), file=sys.stderr)
             elif isinstance(pep257_error, SyntaxError):
                 errors.append({
                     'category': str(type(pep257_error)),
                     'linenumber': '-',
                     'message': 'invalid syntax in file',
                 })
-                print('%s: invalid syntax' % filename)
+                print('%s: invalid syntax' % filename, file=sys.stderr)
             else:
                 errors.append({
                     'category': 'unknown',
                     'linenumber': '-',
                     'message': str(pep257_error),
                 })
-                print('%s: %s' % (filename, pep257_error))
+                print('%s: %s' % (filename, pep257_error), file=sys.stderr)
         report.append((filename, errors))
     return report
 


### PR DESCRIPTION
Resolve #389 

This PR allows the error prints from ament_pep257 to be redirected to the standard error stream, instead of the standard output.

Signed-off-by: Mirco Colosi (CR/AAS3) <Mirco.Colosi@de.bosch.com>