### PR TITLE
ament_clang_tidy - Fix Reporting when WarningsAsErrors is specified in config

### DIFF
--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -206,8 +206,7 @@ def main(argv=sys.argv[1:]):
     for compilation_db in compilation_dbs:
         package_dir = os.path.dirname(compilation_db)
         package_name = os.path.basename(package_dir)
-        print('found compilation database for package "%s"...' % package_name)
-        (source_files, output) = invoke_clang_tidy(compilation_db)
+        print(f"found compilation database for package '{package_name}' at '{compilation_db}'")        (source_files, output) = invoke_clang_tidy(compilation_db)
         files += source_files
         outputs.append(output)
     pool.close()

--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -173,6 +173,9 @@ def main(argv=sys.argv[1:]):
                 print('The invocation of "%s" failed with error code %d: %s' %
                       (os.path.basename(clang_tidy_bin), e.returncode, e),
                       file=sys.stderr)
+                # Attempt to recover output, if any was found (eg - if
+                # WarningsAsErrors was specified in the config file).
+                output = e.output.decode("utf-8")
             return output
 
         files = []
@@ -203,7 +206,7 @@ def main(argv=sys.argv[1:]):
     for compilation_db in compilation_dbs:
         package_dir = os.path.dirname(compilation_db)
         package_name = os.path.basename(package_dir)
-        print(f"found compilation database for package '{package_name}' at '{compilation_db}'")
+        print('found compilation database for package "%s"...' % package_name)
         (source_files, output) = invoke_clang_tidy(compilation_db)
         files += source_files
         outputs.append(output)

--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -175,7 +175,7 @@ def main(argv=sys.argv[1:]):
                       file=sys.stderr)
                 # Attempt to recover output, if any was found (eg - if
                 # WarningsAsErrors was specified in the config file).
-                output = e.output.decode("utf-8")
+                output = e.output.decode('utf-8')
             return output
 
         files = []
@@ -206,7 +206,8 @@ def main(argv=sys.argv[1:]):
     for compilation_db in compilation_dbs:
         package_dir = os.path.dirname(compilation_db)
         package_name = os.path.basename(package_dir)
-        print(f"found compilation database for package '{package_name}' at '{compilation_db}'")        (source_files, output) = invoke_clang_tidy(compilation_db)
+        print(f"found compilation database for package '{package_name}' at '{compilation_db}'")
+        (source_files, output) = invoke_clang_tidy(compilation_db)
         files += source_files
         outputs.append(output)
     pool.close()


### PR DESCRIPTION
## Issue Summary
When `WarningsAsErrors` is specified in `.clang-tidy`, this can lead to some failures in result reporting. Specifically, the following test program (src/factorial.cpp):
```
int Factorial(int n) {
    int result = 1;
    int fake = 1;
    for (int i = 1; i <= n; i++) {
        result *= i;
    }
    return result;
}

```
fails with this output:
```
The invocation of "clang-tidy" failed with error code 1: Command '['/usr/bin/clang-tidy', '-p', 'path/test_examples_cmake', '--header-filter', 'include/test_examples_cmake/.*', 'path']' returned non-zero exit status 1.
```
when running `ament_clang_tidy`.

After applying this fix, I get the following output, which is expected
```
src/factorial.cpp:36:9: error: unused variable 'fake' [clang-diagnostic-unused-variable,-warnings-as-errors]
    int fake = 1;
        ^
```

Relevant section of `.clang-tidy`, for reference:
```
Checks:
    'bugprone*,
     clang-analyzer*,
     cert*,
     performance*,
     portability*,
     readability*,
     hicpp*,
     -hicpp-signed-bitwise,
     google-readability-todo,
    '
FormatStyle:     file
WarningsAsErrors: '*'
```

## Fix
By trying to access the `output` attribute of the raised exception, we can populate the output in cases where exceptions were raised and there was valid output.
