### PR TITLE
Add 'uriBaseId': os.getcwd() to artifacts to allow for absolute path resolution.

### DIFF
--- a/ament_copyright/ament_copyright/main.py
+++ b/ament_copyright/ament_copyright/main.py
@@ -558,7 +558,7 @@ def get_sarif_content(report, testname, elapsed):
 
     for (filename, rule_id, no_error, message) in report:
         # Populate the artifact information (source files analyzed)
-        artifacts.append({'location': {'uri': filename}})
+        artifacts.append({'location': {'uri': filename, 'uriBaseId': os.getcwd()}})
 
         # Process any associated error/warning info associated with this file
         if not no_error:

--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -412,7 +412,7 @@ def get_sarif_content(cppcheck_version, report, testname, elapsed, skip=None):
     # Populate the artifact information (source files analyzed)
     artifacts = sarif['runs'][0]['artifacts']
     for filename in sorted(report.keys()):
-        artifact = {'location': {'uri': filename}}
+        artifact = {'location': {'uri': filename, 'uriBaseId': os.getcwd()}}
         artifacts.append(artifact)
 
     # Populate the results of the analysis (issues discovered)

--- a/ament_uncrustify/ament_uncrustify/main.py
+++ b/ament_uncrustify/ament_uncrustify/main.py
@@ -497,7 +497,7 @@ def get_sarif_content(report, testname, elapsed, uncrustify_version):
 
     for (filename, diff_lines) in report:
         # Populate the artifact information (source files analyzed)
-        artifacts.append({'location': {'uri': filename}})
+        artifacts.append({'location': {'uri': filename, 'uriBaseId': os.getcwd()}})
 
         # Process any associated error/warning info associated with this file
         if diff_lines:


### PR DESCRIPTION
These are the only packages which return SARIF artifacts with a `uri` that is not an absolute path. It is possible there are others in this repository that exhibit the same behavior (relative `uri` with no associated `uriBaseId`), but they are not currently listing those artifacts in their SARIF files.