### PR TITLE
Enable the user of a misra.json config file if the user provides one

### DIFF
--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -167,17 +167,19 @@ def main(argv=sys.argv[1:]):
     if jobs:
         cmd.extend(['-j', '%d' % jobs])
     if args.enable_misra_checks:
-        # The MISRA rule text is copyrighted. If the user happens to provide a misra.json configuration
-        # file that specifies a rule text file to use, use it. Here's an example misra.json:
+        # The MISRA rule text is copyrighted. However, if the user happens to have a misra.json
+        # configuration file in the $HOME directory, use it.
+        #
+        # Here's an example misra.json:
         # {
         #   "script": "/usr/lib/x86_64-linux-gnu/cppcheck/addons/misra.py",
         #   "args": [
-        #      "--rule-texts=/home/spaceros-user/src/spaceros/install/ament_cppcheck/share/ament_cppcheck/misra-rules.txt",
+        #      "--rule-texts=/home/spaceros-user/misra-rules.txt",
         #      "--suppress-rules 17.3,21.12"
         #   ]
         # }
 
-        misra_json = os.path.join(get_package_share_directory('ament_cppcheck'), 'misra.json')
+        misra_json = os.path.join(os.environ['HOME'], 'misra.json')
         cmd.extend([f'--addon={misra_json}']) if os.path.isfile(misra_json) else cmd.extend(['--addon=misra'])
     cmd.extend(files)
     try:

--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -179,7 +179,7 @@ def main(argv=sys.argv[1:]):
         #   ]
         # }
 
-        misra_json = os.path.join(os.environ['HOME'], 'misra.json')
+        misra_json = os.path.join(os.path.expanduser('~'), 'misra.json')
         cmd.extend([f'--addon={misra_json}']) if os.path.isfile(misra_json) else cmd.extend(['--addon=misra'])
     cmd.extend(files)
     try:

--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ament_index_python.packages import get_package_share_directory
 import argparse
 from collections import defaultdict
 import json
@@ -166,7 +167,18 @@ def main(argv=sys.argv[1:]):
     if jobs:
         cmd.extend(['-j', '%d' % jobs])
     if args.enable_misra_checks:
-        cmd.extend(['--addon=misra'])
+        # The MISRA rule text is copyrighted. If the user happens to provide a misra.json configuration
+        # file that specifies a rule text file to use, use it. Here's an example misra.json:
+        # {
+        #   "script": "/usr/lib/x86_64-linux-gnu/cppcheck/addons/misra.py",
+        #   "args": [
+        #      "--rule-texts=/home/spaceros-user/src/spaceros/install/ament_cppcheck/share/ament_cppcheck/misra-rules.txt",
+        #      "--suppress-rules 17.3,21.12"
+        #   ]
+        # }
+
+        misra_json = os.path.join(get_package_share_directory('ament_cppcheck'), 'misra.json')
+        cmd.extend([f'--addon={misra_json}']) if os.path.isfile(misra_json) else cmd.extend(['--addon=misra'])
     cmd.extend(files)
     try:
         p = subprocess.Popen(cmd, stderr=subprocess.PIPE)


### PR DESCRIPTION
The MISRA error text is copyrighted. However, if the user puts together a misra.json file that points to a file that contains the MISRA rules text and puts these in ament_cppcheck's package share directory, the utility will pick up the rules text file and output the correct error messages rather than placeholders that only specify the MISRA rule number. 

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>