### PR TITLE
Fix .index() due to addition of uriBaseId.

### DIFF
--- a/ament_copyright/ament_copyright/main.py
+++ b/ament_copyright/ament_copyright/main.py
@@ -575,7 +575,7 @@ def get_sarif_content(report, testname, elapsed):
             # Populate the results of the analysis (issues discovered)
             message = message
             line = 1  # Indicate copyright issues at the start of the file since we don't have a line number
-            index = artifacts.index({'location': {'uri': filename}})
+            index = artifacts.index({'location': {'uri': filename, 'uriBaseId': os.getcwd()}})
 
             results.append({
                 'ruleId': rule_id,

--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -421,7 +421,7 @@ def get_sarif_content(cppcheck_version, report, testname, elapsed, skip=None):
     for filename in sorted(report.keys()):
         errors = report[filename]
         for error in errors:
-            index = artifacts.index({'location': {'uri': filename}})
+            index = artifacts.index({'location': {'uri': filename, 'uriBaseId': os.getcwd()}})
             results_dict = {
                 'ruleId': error['id'],
                 'level': 'warning',

--- a/ament_uncrustify/ament_uncrustify/main.py
+++ b/ament_uncrustify/ament_uncrustify/main.py
@@ -528,7 +528,7 @@ def get_sarif_content(report, testname, elapsed, uncrustify_version):
                                 'physicalLocation': {
                                     'artifactLocation': {
                                         'uri': filename,
-                                        'index': artifacts.index({'location': {'uri': filename}}),
+                                        'index': artifacts.index({'location': {'uri': filename, 'uriBaseId': os.getcwd()}}),
                                     },
                                     'region': {
                                         'startLine': int(starting_line),


### PR DESCRIPTION
The last PR I submitted (https://github.com/ament/ament_lint/pull/401) contained bugs preventing the conversion of .xml results to .sarif. These changes resolve that bug.
Signed-off-by: Eli Benevedes <ebenevedes@blueorigin.com>