### PR TITLE
Fix compatibility with flake8 version 5

### DIFF
--- a/ament_flake8/ament_flake8/main.py
+++ b/ament_flake8/ament_flake8/main.py
@@ -148,13 +148,28 @@ def get_flake8_style_guide(argv):
             argv)
         flake8.configure_logging(prelim_opts.verbose, prelim_opts.output_file)
         from flake8.options import config
-        config_finder = config.ConfigFileFinder(
-            application.program, prelim_opts.append_config,
-            config_file=prelim_opts.config,
-            ignore_config_files=prelim_opts.isolated)
-        application.find_plugins(config_finder)
-        application.register_plugin_options()
-        application.parse_configuration_and_cli(config_finder, remaining_args)
+        if hasattr(config, "ConfigFileFinder"):
+            config_finder = config.ConfigFileFinder(
+                application.program, prelim_opts.append_config,
+                config_file=prelim_opts.config,
+                ignore_config_files=prelim_opts.isolated)
+            application.find_plugins(config_finder)
+            application.register_plugin_options()
+            application.parse_configuration_and_cli(config_finder, remaining_args)
+        else:
+            cfg, cfg_dir = config.load_config(
+                config=prelim_opts.config,
+                extra=prelim_opts.append_config,
+                isolated=prelim_opts.isolated,
+            )
+            application.find_plugins(
+                cfg,
+                cfg_dir,
+                enable_extensions=prelim_opts.enable_extensions,
+                require_plugins=prelim_opts.require_plugins,
+            )
+            application.register_plugin_options()
+            application.parse_configuration_and_cli(cfg, cfg_dir, remaining_args)
     else:
         application.parse_preliminary_options_and_args([])
         flake8.configure_logging(

--- a/ament_flake8/ament_flake8/main.py
+++ b/ament_flake8/ament_flake8/main.py
@@ -148,7 +148,7 @@ def get_flake8_style_guide(argv):
             argv)
         flake8.configure_logging(prelim_opts.verbose, prelim_opts.output_file)
         from flake8.options import config
-        if hasattr(config, "ConfigFileFinder"):
+        if hasattr(config, 'ConfigFileFinder'):
             config_finder = config.ConfigFileFinder(
                 application.program, prelim_opts.append_config,
                 config_file=prelim_opts.config,
@@ -198,7 +198,7 @@ def parse_config_file(config_file):
     if major_release >= 5:
         opts_manager = manager.OptionManager(
             version=flake8_version,
-            plugin_versions="",
+            plugin_versions='',
             parents=[]
         )
         flake8_options.register_default_options(opts_manager)


### PR DESCRIPTION
The `ConfigFileFinder` class no longer exists in flake8 version 5. The `get_style_guide()` code has been updated from the latest `api.legacy.get_style_guide()` in flake8.
