### PR TITLE
ament_clang_format: use open braces for enum definitions

### DIFF
--- a/ament_clang_format/ament_clang_format/configuration/.clang-format
+++ b/ament_clang_format/ament_clang_format/configuration/.clang-format
@@ -9,6 +9,7 @@ BraceWrapping:
   AfterFunction: true
   AfterNamespace: true
   AfterStruct: true
+  AfterEnum: true
 BreakBeforeBraces: Custom
 ColumnLimit: 100
 ConstructorInitializerIndentWidth: 0


### PR DESCRIPTION
The ROS 2 C++ style guide is [ambiguous about this](https://docs.ros.org/en/rolling/The-ROS2-Project/Contributing/Code-Style-Language-Versions.html#open-versus-cuddled-braces):

> - Use open braces for function, class, and struct definitions, but cuddle braces on if, else, while, for, etc… 
Exception: when an if (or while, etc.) condition is long enough to require line-wrapping, then use an open brace (i.e., don’t cuddle).

It seems more consistent to also use open braces for enum declarations, ie:
```cpp
enum struct Format
{
  OPTION_ONE,
  OPTION_TWO,
};
```