### PR TITLE
Added undescore to ignore new pydocstyle item

### DIFF
--- a/ament_pep257/ament_pep257/main.py
+++ b/ament_pep257/ament_pep257/main.py
@@ -187,13 +187,24 @@ def generate_pep257_report(paths, excludes, ignore, select, convention, add_igno
     report = []
 
     files_dict = {}
-    for filename, checked_codes, ignore_decorators, _ in files_to_check:
-        if _filename_in_excludes(filename, excludes):
-            continue
-        files_dict[filename] = {
-            'select': checked_codes,
-            'ignore_decorators': ignore_decorators,
-        }
+    # Unpack 3 values for pydocstyle <= 6.1.1
+    try:
+        for filename, checked_codes, ignore_decorators in files_to_check:
+            if _filename_in_excludes(filename, excludes):
+                continue
+            files_dict[filename] = {
+                'select': checked_codes,
+                'ignore_decorators': ignore_decorators,
+            }
+    # Unpack 4 values since pydocstyle >= 6.2.0
+    except ValueError:
+        for filename, checked_codes, ignore_decorators, _ in files_to_check:
+            if _filename_in_excludes(filename, excludes):
+                continue
+            files_dict[filename] = {
+                'select': checked_codes,
+                'ignore_decorators': ignore_decorators,
+            }
 
     for filename in sorted(files_dict.keys()):
         print('checking', filename)

--- a/ament_pep257/ament_pep257/main.py
+++ b/ament_pep257/ament_pep257/main.py
@@ -194,7 +194,7 @@ def generate_pep257_report(paths, excludes, ignore, select, convention, add_igno
         files_dict[filename] = {
             'select': checked_codes,
             'ignore_decorators': ignore_decorators,
-        } 
+        }
 
     for filename in sorted(files_dict.keys()):
         print('checking', filename)

--- a/ament_pep257/ament_pep257/main.py
+++ b/ament_pep257/ament_pep257/main.py
@@ -187,7 +187,7 @@ def generate_pep257_report(paths, excludes, ignore, select, convention, add_igno
     report = []
 
     files_dict = {}
-    for filename, checked_codes, ignore_decorators in files_to_check:
+    for filename, checked_codes, ignore_decorators, _ in files_to_check:
         if _filename_in_excludes(filename, excludes):
             continue
         files_dict[filename] = {

--- a/ament_pep257/ament_pep257/main.py
+++ b/ament_pep257/ament_pep257/main.py
@@ -194,7 +194,7 @@ def generate_pep257_report(paths, excludes, ignore, select, convention, add_igno
         files_dict[filename] = {
             'select': checked_codes,
             'ignore_decorators': ignore_decorators,
-        }    
+        } 
 
     for filename in sorted(files_dict.keys()):
         print('checking', filename)

--- a/ament_pep257/ament_pep257/main.py
+++ b/ament_pep257/ament_pep257/main.py
@@ -187,24 +187,14 @@ def generate_pep257_report(paths, excludes, ignore, select, convention, add_igno
     report = []
 
     files_dict = {}
-    # Unpack 3 values for pydocstyle <= 6.1.1
-    try:
-        for filename, checked_codes, ignore_decorators in files_to_check:
-            if _filename_in_excludes(filename, excludes):
-                continue
-            files_dict[filename] = {
-                'select': checked_codes,
-                'ignore_decorators': ignore_decorators,
-            }
-    # Unpack 4 values since pydocstyle >= 6.2.0
-    except ValueError:
-        for filename, checked_codes, ignore_decorators, _ in files_to_check:
-            if _filename_in_excludes(filename, excludes):
-                continue
-            files_dict[filename] = {
-                'select': checked_codes,
-                'ignore_decorators': ignore_decorators,
-            }
+    # Unpack 3 values for pydocstyle <= 6.1.1 and 4 values for pydocstyle >= 6.2.0
+    for filename, checked_codes, ignore_decorators, *_ in files_to_check:
+        if _filename_in_excludes(filename, excludes):
+            continue
+        files_dict[filename] = {
+            'select': checked_codes,
+            'ignore_decorators': ignore_decorators,
+        }    
 
     for filename in sorted(files_dict.keys()):
         print('checking', filename)


### PR DESCRIPTION
Signed-off-by: Crola1702 <cristobal.arroyo@ekumenlabs.com>

[Pydocstyle 6.2.0](https://github.com/PyCQA/pydocstyle/releases/tag/6.2.0) introduced a [new feature](https://github.com/PyCQA/pydocstyle/commit/d4d9d6342ff201b5bb4b672ae35ac3e43968190a#diff-e4d54968958770bba400abd39d13bea987e30f73a2cb87fd94d6fb8d9f366162R298) where `get_files_to_check` method yields 4 items instead of 3.

This PR adds and ignores that item, so the tests can run without crashing.