### PR TITLE
ament_pycodestyle - fix crash caused by reporting on ignored errors

### DIFF
--- a/ament_pycodestyle/ament_pycodestyle/main.py
+++ b/ament_pycodestyle/ament_pycodestyle/main.py
@@ -192,6 +192,9 @@ class CustomReport(pycodestyle.StandardReport):
     def error(self, line_number, offset, text, check):
         code = super(CustomReport, self).error(
             line_number, offset, text, check)
+        if code is None:
+            # Config says to ignore this error
+            return
         line = self.lines[line_number - 1] \
             if line_number <= len(self.lines) else ''
         self.errors.append({

--- a/ament_pycodestyle/test/test_ignore_config.py
+++ b/ament_pycodestyle/test/test_ignore_config.py
@@ -1,0 +1,31 @@
+# Copyright 2023 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib
+import tempfile
+
+from ament_pycodestyle.main import generate_pycodestyle_report
+
+
+def test_can_ignore_errors():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_dir = pathlib.Path(temp_dir)
+        config_file = temp_dir / 'pycodestyle.ini'
+        py_file = temp_dir / 'foobar.py'
+        config_file.write_text('[pycodestyle]\nignore = E226\n')
+        py_file.write_text('a = 1+2\n')
+
+        report = generate_pycodestyle_report(
+            config_file.name, [str(temp_dir)], None)
+        assert [] == report.errors


### PR DESCRIPTION
This fixes a crash caused by the `CustomReport` trying to report errors that have been ignored through a custom `pycodestyle.ini`. This PR should be backported to Humble.

Error this fixes:
```
  3: Traceback (most recent call last):
  3:   File "/opt/ros/humble/bin/ament_pycodestyle", line 33, in <module>
  3:     sys.exit(load_entry_point('ament-pycodestyle==0.12.5', 'console_scripts', 'ament_pycodestyle')())
  3:   File "/opt/ros/humble/lib/python3.10/site-packages/ament_pycodestyle/main.py", line 97, in main
  3:     xml = get_xunit_content(report, testname)
  3:   File "/opt/ros/humble/lib/python3.10/site-packages/ament_pycodestyle/main.py", line 145, in get_xunit_content
  3:     error['error_code'] +
  3: TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```

`BaseReport` [returns None from `error()` when the error code is supposed to be ignored](https://github.com/PyCQA/pycodestyle/blob/b22b672a1a53f1ef35c4f4689c674d66a24138ed/pycodestyle.py#L2219-L2220). `ament_pycodestyle`'s `CustomReport` class was putting it into the `report.errors` list anyways, and that caused a crash when `generate_xunit_content` tried to concatenate `None` with a string.
https://github.com/ament/ament_lint/blob/ecaf9ab8d03ebedb2cdfcb45ce89b5416a26c4bd/ament_pycodestyle/ament_pycodestyle/main.py#L145-L146

This fixes it by making `CustomReport` also return `None` when it's base class does.


