### PR TITLE
remove AMENT_IGNORE check in clang-tidy when looking for compilation db

### DIFF
--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -281,7 +281,7 @@ def get_compilation_db_files(paths):
                 # This function tries to find compile_commands.json file in the build folders.
                 # Build folders always include a AMENT_IGNORE file, so checking for it would
                 # result in not finding any compilation db. The check would also be redundant
-                # because if a source folder was marked with AMENT_IGNORE, then 
+                # because if a source folder was marked with AMENT_IGNORE, then
                 # the compile_commands.json will not be present in relevant build folder.
 
                 # ignore folder starting with . or _

--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -277,6 +277,12 @@ def get_compilation_db_files(paths):
     for path in paths:
         if os.path.isdir(path):
             for dirpath, dirnames, filenames in os.walk(path):
+                # NOTE: here we don't check for the AMENT_IGNORE file.
+                # This function tries to find compile_commands.json file in the build folders.
+                # Build folders always include a AMENT_IGNORE file, so checking for it would result in not finding any compilation db.
+                # The check would also be redundant, because if a source folder was marked with AMENT_IGNORE, then 
+                # the compile_commands.json will not be present in relevant build folder.
+
                 # ignore folder starting with . or _
                 dirnames[:] = [d for d in dirnames if d[0] not in ['.', '_']]
                 dirnames.sort()

--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -279,8 +279,9 @@ def get_compilation_db_files(paths):
             for dirpath, dirnames, filenames in os.walk(path):
                 # NOTE: here we don't check for the AMENT_IGNORE file.
                 # This function tries to find compile_commands.json file in the build folders.
-                # Build folders always include a AMENT_IGNORE file, so checking for it would result in not finding any compilation db.
-                # The check would also be redundant, because if a source folder was marked with AMENT_IGNORE, then 
+                # Build folders always include a AMENT_IGNORE file, so checking for it would
+                # result in not finding any compilation db. The check would also be redundant
+                # because if a source folder was marked with AMENT_IGNORE, then 
                 # the compile_commands.json will not be present in relevant build folder.
 
                 # ignore folder starting with . or _

--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -277,9 +277,6 @@ def get_compilation_db_files(paths):
     for path in paths:
         if os.path.isdir(path):
             for dirpath, dirnames, filenames in os.walk(path):
-                if 'AMENT_IGNORE' in dirnames + filenames:
-                    dirnames[:] = []
-                    continue
                 # ignore folder starting with . or _
                 dirnames[:] = [d for d in dirnames if d[0] not in ['.', '_']]
                 dirnames.sort()


### PR DESCRIPTION
The clang-tidy linter is currently broken in ROS 2 Rolling due to this PR https://github.com/ament/ament_cmake/pull/410

That PR adds an `AMENT_IGNORE` file in all packages build folders.
These folders is where the compilation database is also generated.
Clang-tidy needs the compilation database in order to run, but it currently skips directories with an `AMENT_IGNORE` file in them.

This PR removes this check which seems redundant.
