### PR TITLE
[backport humble] Fix compatibility with flake8 version 5 (#387, #410)

### DIFF
--- a/ament_flake8/ament_flake8/main.py
+++ b/ament_flake8/ament_flake8/main.py
@@ -148,13 +148,28 @@ def get_flake8_style_guide(argv):
             argv)
         flake8.configure_logging(prelim_opts.verbose, prelim_opts.output_file)
         from flake8.options import config
-        config_finder = config.ConfigFileFinder(
-            application.program, prelim_opts.append_config,
-            config_file=prelim_opts.config,
-            ignore_config_files=prelim_opts.isolated)
-        application.find_plugins(config_finder)
-        application.register_plugin_options()
-        application.parse_configuration_and_cli(config_finder, remaining_args)
+        if hasattr(config, 'ConfigFileFinder'):
+            config_finder = config.ConfigFileFinder(
+                application.program, prelim_opts.append_config,
+                config_file=prelim_opts.config,
+                ignore_config_files=prelim_opts.isolated)
+            application.find_plugins(config_finder)
+            application.register_plugin_options()
+            application.parse_configuration_and_cli(config_finder, remaining_args)
+        else:
+            cfg, cfg_dir = config.load_config(
+                config=prelim_opts.config,
+                extra=prelim_opts.append_config,
+                isolated=prelim_opts.isolated,
+            )
+            application.find_plugins(
+                cfg,
+                cfg_dir,
+                enable_extensions=prelim_opts.enable_extensions,
+                require_plugins=prelim_opts.require_plugins,
+            )
+            application.register_plugin_options()
+            application.parse_configuration_and_cli(cfg, cfg_dir, remaining_args)
     else:
         application.parse_preliminary_options_and_args([])
         flake8.configure_logging(
@@ -175,27 +190,41 @@ def get_flake8_style_guide(argv):
 
 
 def parse_config_file(config_file):
+    from flake8 import __version__ as flake8_version, __version_info__ as flake8_version_info
     from flake8.options import config, manager, aggregator
 
-    try:
-        # Support 4.0.0
-        opts_manager = manager.OptionManager(prog='flake8', version='4.0.0')
+    major_release = flake8_version_info[0]
+
+    if major_release >= 5:
+        opts_manager = manager.OptionManager(
+            version=flake8_version,
+            plugin_versions='',
+            parents=[]
+        )
+        flake8_options.register_default_options(opts_manager)
+        cfg, cfg_dir = config.load_config(config_file, [])
+
+        return aggregator.aggregate_options(
+            opts_manager,
+            cfg, cfg_dir,
+            []
+        ), []
+
+    if major_release >= 3:
+        opts_manager = manager.OptionManager(prog='flake8', version=flake8_version)
         flake8_options.register_default_options(opts_manager)
 
         return aggregator.aggregate_options(
             opts_manager,
-            config.ConfigFileFinder('flake8', [], config_file),
+            config.ConfigFileFinder(
+                'flake8',
+                [],
+                config_file if major_release == 4 else [config_file]
+            ),
             []
         )
-    except TypeError:
-        opts_manager = manager.OptionManager(prog='flake8', version='3.0.0')
-        flake8_options.register_default_options(opts_manager)
 
-        return aggregator.aggregate_options(
-            opts_manager,
-            config.ConfigFileFinder('flake8', [], [config_file]),
-            []
-        )
+    raise RuntimeError('flake8 is too old. Please upgrade to version 3.0.0 or newer')
 
 
 def generate_flake8_report(config_file, paths, excludes, max_line_length=None):


### PR DESCRIPTION
This is a combined backport of #387 and #410 to Humble.


When building on Ubuntu 20.04 Focal (Tier 3 support) and following the instructions in https://docs.ros.org/en/humble/Installation/Alternatives/Ubuntu-Development-Setup.html#install-development-tools-and-ros-tools for that platform, `flake8` is installed via `pip` and so is installed at the newer version 5.
`ament_lint` then fails to run with:

```
/opt/ros/humble/install/lib/python3.8/site-packages/ament_flake8/main.py:150: in get_flake8_style_guide
    config_finder = config.ConfigFileFinder(
E   AttributeError: module 'flake8.options.config' has no attribute 'ConfigFileFinder'
```

## 387 original text

This PR fixes https://github.com/ament/ament_lint/issues/382 by explicitly adding any exclude args in the flake8 config file (normally configuration/ament_flake8.ini) to the exclude arglist.

Notably, this uses the same parsing logic that the version of flake8 ROS is using on focal and jammy (3.9.7 and 4.0.0).
I tried to account for differences in the parsing logic between 3.9.7 and 4.0.0 with a try except clause.

## 410 original text

* Fix compatibility with flake8 version 5

The ConfigFileFinder class no longer exists in flake8 version 5.
The get_style_guide() code has been updated from the latest
api.legacy.get_style_guide() in flake8.