### PR TITLE
Pass --output argument to cpplint

### DIFF
--- a/ament_cpplint/ament_cpplint/main.py
+++ b/ament_cpplint/ament_cpplint/main.py
@@ -83,6 +83,9 @@ def main(argv=sys.argv[1:]):
         nargs='*',
         help='Exclude C/C++ files from being checked.')
     parser.add_argument(
+        '--output', type=str,
+        help='The --output option for cpplint')
+    parser.add_argument(
         'paths',
         nargs='*',
         default=[os.curdir],
@@ -102,6 +105,8 @@ def main(argv=sys.argv[1:]):
     argv = []
     # collect category based counts
     argv.append('--counting=detailed')
+    if args.output:
+        argv.append('--output=%s' % args.output)
     argv.append('--extensions=%s' % ','.join(extensions))
     argv.append('--headers=%s' % ','.join(headers))
     filters = [


### PR DESCRIPTION
- Adds option to pass the `--output` command line argument to cpplint

This is useful for integration with IDEs that expect the lintier to provide output in a specific format, e.g. for VSCode with the cpplint extension use `--output=eclipse`.