### PR TITLE
Changes to make ament_flake8 work with v6+

### DIFF
--- a/ament_flake8/ament_flake8/main.py
+++ b/ament_flake8/ament_flake8/main.py
@@ -143,6 +143,7 @@ def get_flake8_style_guide(argv):
     # appropriate options to pass into the standard flake8.legacy.get_style_guide();
     # passing argv gets it to determine the options for us.
     application = flake8_app.Application()
+
     if hasattr(application, 'parse_preliminary_options'):
         prelim_opts, remaining_args = application.parse_preliminary_options(
             argv)
@@ -170,7 +171,7 @@ def get_flake8_style_guide(argv):
             )
             application.register_plugin_options()
             application.parse_configuration_and_cli(cfg, cfg_dir, remaining_args)
-    else:
+    elif hasattr(application, 'parse_preliminary_options_and_args'):
         application.parse_preliminary_options_and_args([])
         flake8.configure_logging(
             application.prelim_opts.verbose, application.prelim_opts.output_file)
@@ -178,6 +179,11 @@ def get_flake8_style_guide(argv):
         application.find_plugins()
         application.register_plugin_options()
         application.parse_configuration_and_cli(argv)
+    else:
+        # Flake8 >= 6 uses parse_args
+        # Ref: https://github.com/PyCQA/flake8/commit/0d667a73299971f1cf8ff549c519fffb282b1faf
+        from flake8.options.parse_args import parse_args
+        application.plugins, application.options = parse_args(argv)
     application.make_formatter()
     try:
         # needed in older flake8 versions to populate the listener
@@ -185,7 +191,7 @@ def get_flake8_style_guide(argv):
     except AttributeError:
         pass
     application.make_guide()
-    application.make_file_checker_manager()
+    application.make_file_checker_manager(argv)
     return StyleGuide(application)
 
 
@@ -199,7 +205,8 @@ def parse_config_file(config_file):
         opts_manager = manager.OptionManager(
             version=flake8_version,
             plugin_versions='',
-            parents=[]
+            parents=[],
+            formatter_names=[],
         )
         flake8_options.register_default_options(opts_manager)
         cfg, cfg_dir = config.load_config(config_file, [])
@@ -260,8 +267,13 @@ def generate_flake8_report(config_file, paths, excludes, max_line_length=None):
 
     # Get the names of files checked
     report.report = style.check_files(paths)
-    file_checkers = style._application.file_checker_manager.checkers
-    report.files = [file_checker.filename for file_checker in file_checkers]
+
+    # Flake8 < 6 uses 'checkers' attribute
+    if hasattr(style._application.file_checker_manager, 'checkers'):
+        file_checkers = style._application.file_checker_manager.checkers
+        report.files = [file_checker.filename for file_checker in file_checkers]
+    else:
+        report.files = style._application.file_checker_manager.filenames
 
     assert report.report.total_errors == len(report.errors)
     return report

--- a/ament_flake8/ament_flake8/main.py
+++ b/ament_flake8/ament_flake8/main.py
@@ -207,12 +207,19 @@ def parse_config_file(config_file):
     major_release = flake8_version_info[0]
 
     if major_release >= 5:
-        opts_manager = manager.OptionManager(
-            version=flake8_version,
-            plugin_versions='',
-            parents=[],
-            formatter_names=[],
-        )
+        if major_release == 5:
+            opts_manager = manager.OptionManager(
+                version=flake8_version,
+                plugin_versions='',
+                parents=[],
+            )
+        else:
+            opts_manager = manager.OptionManager(
+                version=flake8_version,
+                plugin_versions='',
+                parents=[],
+                formatter_names=[],
+            )
         flake8_options.register_default_options(opts_manager)
         cfg, cfg_dir = config.load_config(config_file, [])
 

--- a/ament_flake8/ament_flake8/main.py
+++ b/ament_flake8/ament_flake8/main.py
@@ -143,7 +143,7 @@ def get_flake8_style_guide(argv):
     # appropriate options to pass into the standard flake8.legacy.get_style_guide();
     # passing argv gets it to determine the options for us.
     application = flake8_app.Application()
-
+    file_checker_takes_argv = False
     if hasattr(application, 'parse_preliminary_options'):
         prelim_opts, remaining_args = application.parse_preliminary_options(
             argv)
@@ -184,6 +184,7 @@ def get_flake8_style_guide(argv):
         # Ref: https://github.com/PyCQA/flake8/commit/0d667a73299971f1cf8ff549c519fffb282b1faf
         from flake8.options.parse_args import parse_args
         application.plugins, application.options = parse_args(argv)
+        file_checker_takes_argv = True
     application.make_formatter()
     try:
         # needed in older flake8 versions to populate the listener
@@ -191,7 +192,11 @@ def get_flake8_style_guide(argv):
     except AttributeError:
         pass
     application.make_guide()
-    application.make_file_checker_manager(argv)
+
+    if file_checker_takes_argv:
+        application.make_file_checker_manager(argv)
+    else:
+        application.make_file_checker_manager()
     return StyleGuide(application)
 
 


### PR DESCRIPTION
`parse_preliminary_options_and_args` and `parse_preliminary_options` have both been removed in favor of `parse_args` in this commit: https://github.com/PyCQA/flake8/commit/0d667a73299971f1cf8ff549c519fffb282b1faf

(No corresponding PR as far as I can tell).

This is the minimal set of changes to get build/test passing on flake8 v6