### PR TITLE
Uncomment version-agnostic Clang-Tidy binary for Foxy release

### DIFF
--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -96,7 +96,7 @@ def main(argv=sys.argv[1:]):
         return 1
 
     bin_names = [
-        # 'clang-tidy',
+        'clang-tidy',
         'clang-tidy-6.0',
     ]
     clang_tidy_bin = find_executable(bin_names)


### PR DESCRIPTION
This PR uncomments the version-agnostic `clang-tidy` binary string in the `ament_clang_tidy` package, effectively backporting a change from the Humble release. Some projects still use ROS 2 Foxy, so giving them the option to use newer Clang-Tidy versions would be helpful.

For some reason, the version-agnostic Clang-Tidy binary string got commented out in commit 25770af. There wasn't any context in the commit message, and I could not find rationales in existing issues/PRs.