### PR TITLE
Fix a warning from newer versions of flake8.

### DIFF
--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -154,8 +154,8 @@ def main(argv=sys.argv[1:]):
             cmd.append('--system-headers')
 
         def is_gtest_source(file_name):
-            if(file_name == 'gtest_main.cc' or file_name == 'gtest-all.cc'
-               or file_name == 'gmock_main.cc' or file_name == 'gmock-all.cc'):
+            if file_name == 'gtest_main.cc' or file_name == 'gtest-all.cc' \
+               or file_name == 'gmock_main.cc' or file_name == 'gmock-all.cc':
                 return True
             return False
 


### PR DESCRIPTION
The parentheses are unnecessary.  This will make flake8 5.0.4 happy (which is what will be in Ubuntu 24.04).