### PR TITLE
Fix a flake8 warning in ament_mypy.

### DIFF
--- a/ament_mypy/test/test_ament_mypy.py
+++ b/ament_mypy/test/test_ament_mypy.py
@@ -260,4 +260,4 @@ def test__get_xunit_content(mocker, sample_errors):
                                              [err.group('filename') for err in errors], .01)
     root = ET.fromstring(xml)
     assert root.get('failures') == '0'
-    assert(len(root)) == 2
+    assert len(root) == 2


### PR DESCRIPTION
No need for parentheses around an assert.