### PR TITLE
Add an ament_lint test dependency on python3-pytest.

### DIFF
--- a/ament_lint/package.xml
+++ b/ament_lint/package.xml
@@ -17,6 +17,8 @@
   <author>Dirk Thomas</author>
   <author email="michel@ekumenlabs.com">Michel Hidalgo</author>
 
+  <test_depend>python3-pytest</test_depend>
+
   <export>
     <build_type>ament_python</build_type>
   </export>

--- a/ament_lint/setup.py
+++ b/ament_lint/setup.py
@@ -32,6 +32,7 @@ setup(
 Providing common API for ament linter packages, e.g. the `linter` marker for
 pytest.""",
     license='Apache License, Version 2.0',
+    tests_require=['pytest'],
     entry_points={
         'pytest11': [
             'ament_lint = ament_lint.pytest_marker',


### PR DESCRIPTION
While we don't actually have any tests in here, this ensures that colcon will use pytest (and not unittest) to run any tests.