### PR TITLE
Try to find an flake8 config file in the local package

### DIFF
--- a/ament_flake8/ament_flake8/main.py
+++ b/ament_flake8/ament_flake8/main.py
@@ -34,6 +34,10 @@ def main(argv=sys.argv[1:]):
 
 def main_with_errors(argv=sys.argv[1:]):
     config_file = os.path.join(
+        os.getcwd(), 'test', 'configuration', 'ament_flake8.ini')
+
+    if not os.path.isfile(config_file):
+      config_file = os.path.join(
         os.path.dirname(__file__), 'configuration', 'ament_flake8.ini')
 
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
It will be great to be able to define my own ament_flake8.ini configuration file locally, instead of using the default one.

This PR propose a fix. When a ROS Python package is created there is a folder called test with a `test_flake8.py` file that launches the test. I propose to put there your own config (if you want)
 - test/configuration/ament_flake8.ini

Otherwise I need to modify the `test_flake8.py` I think this solution is cleaner.

Thoughts?