### PR TITLE
(cmake_xmllint) make extensions configurable

### DIFF
--- a/ament_cmake_xmllint/cmake/ament_cmake_xmllint_lint_hook.cmake
+++ b/ament_cmake_xmllint/cmake/ament_cmake_xmllint_lint_hook.cmake
@@ -12,8 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-file(GLOB_RECURSE _source_files FOLLOW_SYMLINKS "*.xml")
+# Forces ament_xmllint to consider ament_cmake_xmllint_EXTENSIONS as the given extensions if defined
+set(_extensions "xml")
+if(DEFINED ament_cmake_xmllint_EXTENSIONS)
+  string(REGEX REPLACE "[ \\*\\.,]+" ";" _extensions ${ament_cmake_xmllint_EXTENSIONS})
+  message(STATUS "Configured xmllint extensions: ${_extensions}")
+endif()
+
+# Make sure all extensions start with '*.' or add it if not
+foreach(_extension ${_extensions})
+  string(REGEX MATCH "^\\*?\\.?(.+)$" _bare_extension ${_extension})
+  list(APPEND _glob_extensions "*.${_bare_extension}")
+endforeach()
+
+message(DEBUG "Globbing for xml files with extensions: ${_glob_extensions}")
+
+file(GLOB_RECURSE _source_files FOLLOW_SYMLINKS ${_glob_extensions})
 if(_source_files)
+  message(DEBUG "Found files with extensions: ${_source_files}")
   message(STATUS "Added test 'xmllint' to check XML markup files")
-  ament_xmllint()
+  ament_xmllint(EXTENSIONS ${_extensions})
+else()
+  message(DEBUG "No files with extensions: ${_extensions} found, skipping test 'xmllint'")
 endif()

--- a/ament_cmake_xmllint/cmake/ament_xmllint.cmake
+++ b/ament_cmake_xmllint/cmake/ament_xmllint.cmake
@@ -43,7 +43,21 @@ function(ament_xmllint)
     endforeach()
   endif()
 
+  if(ARG_EXCLUDE)
+    list(APPEND cmd "--exclude")
+    foreach(ex ${ARG_EXCLUDE})
+      list(APPEND cmd "${ex}")
+    endforeach()
+  endif()
+
   list(APPEND cmd ${ARG_UNPARSED_ARGUMENTS})
+
+  if(ARG_PATHS)
+    list(APPEND cmd "--")
+    foreach(path ${ARG_PATHS})
+      list(APPEND cmd "${path}")
+    endforeach()
+  endif()
 
   find_program(xmllint_BIN NAMES "xmllint")
 

--- a/ament_cmake_xmllint/cmake/ament_xmllint.cmake
+++ b/ament_cmake_xmllint/cmake/ament_xmllint.cmake
@@ -23,7 +23,7 @@
 # @public
 #
 function(ament_xmllint)
-  cmake_parse_arguments(ARG "" "MAX_LINE_LENGTH;TESTNAME" "" ${ARGN})
+  cmake_parse_arguments(ARG "" "TESTNAME" "PATHS;EXCLUDE;EXTENSIONS" ${ARGN})
   if(NOT ARG_TESTNAME)
     set(ARG_TESTNAME "xmllint")
   endif()
@@ -35,6 +35,14 @@ function(ament_xmllint)
 
   set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.xunit.xml")
   set(cmd "${ament_xmllint_BIN}" "--xunit-file" "${result_file}")
+
+  if(ARG_EXTENSIONS)
+    list(APPEND cmd "--extensions")
+    foreach(ext ${ARG_EXTENSIONS})
+      list(APPEND cmd "${ext}")
+    endforeach()
+  endif()
+
   list(APPEND cmd ${ARG_UNPARSED_ARGUMENTS})
 
   find_program(xmllint_BIN NAMES "xmllint")

--- a/ament_cmake_xmllint/doc/index.rst
+++ b/ament_cmake_xmllint/doc/index.rst
@@ -29,12 +29,29 @@ How to run the check from within a CMake ament package as part of the tests?
     find_package(ament_cmake REQUIRED)
     if(BUILD_TESTING)
       find_package(ament_cmake_xmllint REQUIRED)
-      ament_xmllint()
+      ament_xmllint(
+        # PATHS .
+        # EXCLUDE specific_file.xml
+        # EXTENSIONS xml urdf xacro
+      )
     endif()
 
 When running multiple linters as part of the CMake tests the documentation of
 the package `ament_lint_auto <https://github.com/ament/ament_lint>`_ might
 contain some useful information.
+
+When you want to customize the extensions of the files to be checked, while using `ament_lint_auto`, you can use the following code snippet:
+
+``CMakeLists.txt``:
+
+.. code:: cmake
+
+    find_package(ament_cmake REQUIRED)
+    if(BUILD_TESTING)
+      find_package(ament_lint_auto REQUIRED)
+      set(ament_cmake_xmllint_EXTENSIONS "xml urdf xacro")
+      ament_lint_auto_find_test_dependencies()
+    endif()
 
 The documentation of the package `ament_cmake_test
 <https://github.com/ament/ament_cmake>`_ provides more information on testing


### PR DESCRIPTION
Make it possible to configure the file extensions to be checked by xmllint from CMake.

This can be done by setting the `ament_cmake_xmllint_EXTENSIONS` as a space or comma separated string of extensions when using `ament_lint_auto`. Or by passing the `EXTENSIONS` to `ament_xmllint` function directly.