### PR TITLE
Add AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS flag

### DIFF
--- a/ament_cmake_clang_format/cmake/ament_clang_format.cmake
+++ b/ament_cmake_clang_format/cmake/ament_clang_format.cmake
@@ -39,6 +39,15 @@ function(ament_clang_format)
     set(ARG_TESTNAME "clang_format")
   endif()
 
+  # https://cmake.org/cmake/help/latest/prop_dir/TESTS.html
+  get_directory_property(_declared_tests TESTS)
+  if(DEFINED AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS)
+    if((AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS) AND (${ARG_TESTNAME} IN_LIST _declared_tests))
+      message(VERBOSE "skipping test '${ARG_TESTNAME}' as it has already been added")
+      return()
+    endif()
+  endif()
+
   find_program(ament_clang_format_BIN NAMES "ament_clang_format")
   if(NOT ament_clang_format_BIN)
     message(FATAL_ERROR "ament_clang_format() variable 'ament_clang_format_BIN' must not be empty")

--- a/ament_cmake_clang_tidy/cmake/ament_clang_tidy.cmake
+++ b/ament_cmake_clang_tidy/cmake/ament_clang_tidy.cmake
@@ -40,6 +40,15 @@ function(ament_clang_tidy)
     set(ARG_TESTNAME "clang_tidy")
   endif()
 
+  # https://cmake.org/cmake/help/latest/prop_dir/TESTS.html
+  get_directory_property(_declared_tests TESTS)
+  if(DEFINED AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS)
+    if((AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS) AND (${ARG_TESTNAME} IN_LIST _declared_tests))
+      message(VERBOSE "skipping test '${ARG_TESTNAME}' as it has already been added")
+      return()
+    endif()
+  endif()
+
   find_program(ament_clang_tidy_BIN NAMES "ament_clang_tidy")
   if(NOT ament_clang_tidy_BIN)
     message(FATAL_ERROR "ament_clang_tidy() variable 'ament_clang_tidy_BIN' must not be empty")

--- a/ament_cmake_copyright/cmake/ament_copyright.cmake
+++ b/ament_cmake_copyright/cmake/ament_copyright.cmake
@@ -33,6 +33,15 @@ function(ament_copyright)
     set(ARG_TIMEOUT 120)
   endif()
 
+  # https://cmake.org/cmake/help/latest/prop_dir/TESTS.html
+  get_directory_property(_declared_tests TESTS)
+  if(DEFINED AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS)
+    if((AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS) AND (${ARG_TESTNAME} IN_LIST _declared_tests))
+      message(VERBOSE "skipping test '${ARG_TESTNAME}' as it has already been added")
+      return()
+    endif()
+  endif()
+
   find_program(ament_copyright_BIN NAMES "ament_copyright")
   if(NOT ament_copyright_BIN)
     message(FATAL_ERROR "ament_copyright() could not find program 'ament_copyright'")

--- a/ament_cmake_cppcheck/cmake/ament_cppcheck.cmake
+++ b/ament_cmake_cppcheck/cmake/ament_cppcheck.cmake
@@ -40,6 +40,15 @@ function(ament_cppcheck)
     set(ARG_TESTNAME "cppcheck")
   endif()
 
+  # https://cmake.org/cmake/help/latest/prop_dir/TESTS.html
+  get_directory_property(_declared_tests TESTS)
+  if(DEFINED AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS)
+    if((AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS) AND (${ARG_TESTNAME} IN_LIST _declared_tests))
+      message(VERBOSE "skipping test '${ARG_TESTNAME}' as it has already been added")
+      return()
+    endif()
+  endif()
+
   find_program(ament_cppcheck_BIN NAMES "ament_cppcheck")
   if(NOT ament_cppcheck_BIN)
     message(FATAL_ERROR "ament_cppcheck() could not find program 'ament_cppcheck'")

--- a/ament_cmake_cpplint/cmake/ament_cpplint.cmake
+++ b/ament_cmake_cpplint/cmake/ament_cpplint.cmake
@@ -39,6 +39,15 @@ function(ament_cpplint)
     set(ARG_TESTNAME "cpplint")
   endif()
 
+  # https://cmake.org/cmake/help/latest/prop_dir/TESTS.html
+  get_directory_property(_declared_tests TESTS)
+  if(DEFINED AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS)
+    if((AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS) AND (${ARG_TESTNAME} IN_LIST _declared_tests))
+      message(VERBOSE "skipping test '${ARG_TESTNAME}' as it has already been added")
+      return()
+    endif()
+  endif()
+
   find_program(ament_cpplint_BIN NAMES "ament_cpplint")
   if(NOT ament_cpplint_BIN)
     message(FATAL_ERROR "ament_cpplint() could not find program 'ament_cpplint'")

--- a/ament_cmake_flake8/cmake/ament_flake8.cmake
+++ b/ament_cmake_flake8/cmake/ament_flake8.cmake
@@ -32,6 +32,15 @@ function(ament_flake8)
     set(ARG_TESTNAME "flake8")
   endif()
 
+  # https://cmake.org/cmake/help/latest/prop_dir/TESTS.html
+  get_directory_property(_declared_tests TESTS)
+  if(DEFINED AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS)
+    if((AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS) AND (${ARG_TESTNAME} IN_LIST _declared_tests))
+      message(VERBOSE "skipping test '${ARG_TESTNAME}' as it has already been added")
+      return()
+    endif()
+  endif()
+
   find_program(ament_flake8_BIN NAMES "ament_flake8")
   if(NOT ament_flake8_BIN)
     message(FATAL_ERROR "ament_flake8() could not find program 'ament_flake8'")

--- a/ament_cmake_lint_cmake/cmake/ament_lint_cmake.cmake
+++ b/ament_cmake_lint_cmake/cmake/ament_lint_cmake.cmake
@@ -31,6 +31,15 @@ function(ament_lint_cmake)
     set(ARG_TESTNAME "lint_cmake")
   endif()
 
+  # https://cmake.org/cmake/help/latest/prop_dir/TESTS.html
+  get_directory_property(_declared_tests TESTS)
+  if(DEFINED AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS)
+    if((AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS) AND (${ARG_TESTNAME} IN_LIST _declared_tests))
+      message(VERBOSE "skipping test '${ARG_TESTNAME}' as it has already been added")
+      return()
+    endif()
+  endif()
+
   find_program(ament_lint_cmake_BIN NAMES "ament_lint_cmake")
   if(NOT ament_lint_cmake_BIN)
     message(FATAL_ERROR "ament_lint_cmake() could not find program 'ament_lint_cmake'")

--- a/ament_cmake_mypy/cmake/ament_mypy.cmake
+++ b/ament_cmake_mypy/cmake/ament_mypy.cmake
@@ -30,6 +30,15 @@ function(ament_mypy)
     set(ARG_TESTNAME "mypy")
   endif()
 
+  # https://cmake.org/cmake/help/latest/prop_dir/TESTS.html
+  get_directory_property(_declared_tests TESTS)
+  if(DEFINED AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS)
+    if((AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS) AND (${ARG_TESTNAME} IN_LIST _declared_tests))
+      message(VERBOSE "skipping test '${ARG_TESTNAME}' as it has already been added")
+      return()
+    endif()
+  endif()
+
   find_program(ament_mypy_BIN NAMES "ament_mypy")
   if(NOT ament_mypy_BIN)
     message(FATAL_ERROR "ament_mypy() could not find program 'ament_mypy'")

--- a/ament_cmake_pclint/cmake/ament_pclint.cmake
+++ b/ament_cmake_pclint/cmake/ament_pclint.cmake
@@ -35,6 +35,15 @@ function(ament_pclint)
     set(ARG_TESTNAME "pclint")
   endif()
 
+  # https://cmake.org/cmake/help/latest/prop_dir/TESTS.html
+  get_directory_property(_declared_tests TESTS)
+  if(DEFINED AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS)
+    if((AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS) AND (${ARG_TESTNAME} IN_LIST _declared_tests))
+      message(VERBOSE "skipping test '${ARG_TESTNAME}' as it has already been added")
+      return()
+    endif()
+  endif()
+
   find_program(ament_pclint_BIN NAMES "ament_pclint")
   if(NOT ament_pclint_BIN)
     message(FATAL_ERROR "ament_pclint() could not find program 'ament_pclint'")

--- a/ament_cmake_pep257/cmake/ament_pep257.cmake
+++ b/ament_cmake_pep257/cmake/ament_pep257.cmake
@@ -28,6 +28,15 @@ function(ament_pep257)
     set(ARG_TESTNAME "pep257")
   endif()
 
+  # https://cmake.org/cmake/help/latest/prop_dir/TESTS.html
+  get_directory_property(_declared_tests TESTS)
+  if(DEFINED AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS)
+    if((AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS) AND (${ARG_TESTNAME} IN_LIST _declared_tests))
+      message(VERBOSE "skipping test '${ARG_TESTNAME}' as it has already been added")
+      return()
+    endif()
+  endif()
+
   find_program(ament_pep257_BIN NAMES "ament_pep257")
   if(NOT ament_pep257_BIN)
     message(FATAL_ERROR "ament_pep257() could not find program 'ament_pep257'")

--- a/ament_cmake_pycodestyle/cmake/ament_pycodestyle.cmake
+++ b/ament_cmake_pycodestyle/cmake/ament_pycodestyle.cmake
@@ -31,6 +31,15 @@ function(ament_pycodestyle)
     set(ARG_TESTNAME "pycodestyle")
   endif()
 
+  # https://cmake.org/cmake/help/latest/prop_dir/TESTS.html
+  get_directory_property(_declared_tests TESTS)
+  if(DEFINED AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS)
+    if((AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS) AND (${ARG_TESTNAME} IN_LIST _declared_tests))
+      message(VERBOSE "skipping test '${ARG_TESTNAME}' as it has already been added")
+      return()
+    endif()
+  endif()
+
   find_program(ament_pycodestyle_BIN NAMES "ament_pycodestyle")
   if(NOT ament_pycodestyle_BIN)
     message(FATAL_ERROR "ament_pycodestyle() could not find program 'ament_pycodestyle'")

--- a/ament_cmake_pyflakes/cmake/ament_pyflakes.cmake
+++ b/ament_cmake_pyflakes/cmake/ament_pyflakes.cmake
@@ -28,6 +28,15 @@ function(ament_pyflakes)
     set(ARG_TESTNAME "pyflakes")
   endif()
 
+  # https://cmake.org/cmake/help/latest/prop_dir/TESTS.html
+  get_directory_property(_declared_tests TESTS)
+  if(DEFINED AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS)
+    if((AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS) AND (${ARG_TESTNAME} IN_LIST _declared_tests))
+      message(VERBOSE "skipping test '${ARG_TESTNAME}' as it has already been added")
+      return()
+    endif()
+  endif()
+
   find_program(ament_pyflakes_BIN NAMES "ament_pyflakes")
   if(NOT ament_pyflakes_BIN)
     message(FATAL_ERROR "ament_pyflakes() could not find program 'ament_pyflakes'")

--- a/ament_cmake_uncrustify/cmake/ament_uncrustify.cmake
+++ b/ament_cmake_uncrustify/cmake/ament_uncrustify.cmake
@@ -42,6 +42,15 @@ function(ament_uncrustify)
     set(ARG_TESTNAME "uncrustify")
   endif()
 
+  # https://cmake.org/cmake/help/latest/prop_dir/TESTS.html
+  get_directory_property(_declared_tests TESTS)
+  if(DEFINED AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS)
+    if((AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS) AND (${ARG_TESTNAME} IN_LIST _declared_tests))
+      message(VERBOSE "skipping test '${ARG_TESTNAME}' as it has already been added")
+      return()
+    endif()
+  endif()
+
   find_program(ament_uncrustify_BIN NAMES "ament_uncrustify")
   if(NOT ament_uncrustify_BIN)
     message(FATAL_ERROR "ament_uncrustify() could not find program 'ament_uncrustify'")

--- a/ament_cmake_xmllint/cmake/ament_xmllint.cmake
+++ b/ament_cmake_xmllint/cmake/ament_xmllint.cmake
@@ -28,6 +28,15 @@ function(ament_xmllint)
     set(ARG_TESTNAME "xmllint")
   endif()
 
+  # https://cmake.org/cmake/help/latest/prop_dir/TESTS.html
+  get_directory_property(_declared_tests TESTS)
+  if(DEFINED AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS)
+    if((AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS) AND (${ARG_TESTNAME} IN_LIST _declared_tests))
+      message(VERBOSE "skipping test '${ARG_TESTNAME}' as it has already been added")
+      return()
+    endif()
+  endif()
+
   find_program(ament_xmllint_BIN NAMES "ament_xmllint")
   if(NOT ament_xmllint_BIN)
     message(FATAL_ERROR "ament_xmllint() could not find program 'ament_xmllint'")

--- a/ament_lint_auto/doc/index.rst
+++ b/ament_lint_auto/doc/index.rst
@@ -43,3 +43,53 @@ sufficient to test with a set of common linters.
 The documentation of the package `ament_cmake_test
 <https://github.com/ament/ament_cmake>`_ provides more information on testing
 in CMake ament packages.
+
+
+How to make ``ament_lint_auto`` work with linter macros?
+--------------------------------------------------------
+Lets consider the following code snippet:
+
+``CMakeLists.txt``:
+
+.. code:: cmake
+
+    find_package(ament_cmake_cpplint REQUIRED)
+    find_package(ament_lint_auto REQUIRED)
+    find_package(ament_lint_common REQUIRED)
+    ament_cpplint(
+        MAX_LINE_LENGTH 90
+    )
+    # This code snippet will fail
+
+By default, this code fails, as ``ament_cpplint`` macro is invoked twice - once directly in ``CMakeLists.txt`` file, and once by the ``ament_lint_auto`` hook.
+
+Setting the ``AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS`` flag allows ``ament_lint_auto`` to skip linters already invoked directly in the ``CMakeLists.txt`` file.
+
+For example:
+
+``CMakeLists.txt``:
+
+.. code:: cmake
+
+    set(AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS ON)
+    find_package(ament_cmake_cpplint REQUIRED)
+    find_package(ament_lint_auto REQUIRED)
+    find_package(ament_lint_common REQUIRED)
+    ament_cpplint(
+        MAX_LINE_LENGTH 90
+    )
+    # This code snippet works, and settings from the CMakeLists.txt are passed to ``cpplint`` linter.
+
+Possible use cases for this flag include:
+
+**1. Custom Linter Settings**
+
+``AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS`` allows to directly call a linter macro with specific settings not supported by ``ament_lint_auto`` hooks, while using ``ament_lint_common`` for remaining linters.
+
+**2. Common Linter Set**
+
+The flag makes it possible to declare a common set of linters for all packages in a ROS workspace, regardless of content of ``CMakeLists.txt`` files of packages. 
+
+To declare common set of linters, inject a CMake script during the workspace build, using ``CMAKE_PROJECT_INCLUDE`` build. In that script, enable the flag, and invoke ``ament_lint_auto`` with desired set of linters.
+
+Enabling the flag avoids test re-definition errors for packages that directly call linter macros. This approach is used in SpaceROS to ensure that common set of linters is called for all applicable ROS packages.


### PR DESCRIPTION
## Summary
Added a flag `AMENT_LINT_AUTO_SKIP_PREEXISTING_TESTS` to every test in the repo. If the flag is defined and set to `ON`,  then already added tests (matched by name) are ignored.  This is contrary to default behavior of ament_lint_auto, as by default duplicate test names cause build failure.
The code is backward compatible -> added piece of code has no effect, unless the flag is set.

## Use case
This flag helps to solve https://github.com/space-ros/space-ros/issues/57.  The main idea for resolution of that issue is to inject additional cmake script during build using [CMAKE_PROJECT_INCLUDE](https://cmake.org/cmake/help/latest/variable/CMAKE_PROJECT_INCLUDE.html) variable, that will add linters to packages. Check linked issue and [README in the PR](https://github.com/space-ros/space-ros/pull/145/files#diff-af72128dd2406e40947d93930b80ba6811d8bbbbbf338810733a77640b3be038) for more details.

