### PR TITLE
Small fixes for modern flake8.

### DIFF
--- a/ament_copyright/ament_copyright/main.py
+++ b/ament_copyright/ament_copyright/main.py
@@ -267,7 +267,7 @@ def add_missing_header(file_descriptors, name, license_, verbose):
 
 def add_copyright_year(file_descriptors, new_years, verbose):
     if verbose:
-        print(f'Adding {",".join(map(str,new_years))} to existing copyright notices:')
+        print(f'Adding {",".join(map(str, new_years))} to existing copyright notices:')
         print()
 
     for path in sorted(file_descriptors.keys()):

--- a/ament_copyright/ament_copyright/parser.py
+++ b/ament_copyright/ament_copyright/parser.py
@@ -347,7 +347,7 @@ def remove_formatting(text):
 
 # Flat list of sections split on all separators provided
 def split_template(sections, separators):
-    if type(sections) != list:
+    if not isinstance(sections, list):
         return split_template([sections], separators)
     elif len(separators) > 1:
         return sum([split_template([section], separators[0:1]) for section


### PR DESCRIPTION
This should fix warnings that come up with flake8 7.0 or newer (in Ubuntu 24.04), and are also backwards compatible with flake8 4.0.1 (in Ubuntu 22.04)