### PR TITLE
Fix error path for search_copyright_information.

### DIFF
--- a/ament_copyright/ament_copyright/parser.py
+++ b/ament_copyright/ament_copyright/parser.py
@@ -182,7 +182,7 @@ def determine_filetype(path):
 
 def search_copyright_information(content):
     if content is None:
-        return [], content
+        return [], [], [], content
     # regex for matching years or year ranges (yyyy-yyyy) separated by colons
     year = r'\d{4}'
     year_range = '%s-%s' % (year, year)


### PR DESCRIPTION
Callers now expect it to return a 4-tuple, but in the case that there was no data it was only returning a 2-tuple.