### PR TITLE
Add the rest of the flake8 plugins as dependencies.

### DIFF
--- a/ament_flake8/package.xml
+++ b/ament_flake8/package.xml
@@ -19,14 +19,11 @@
 
   <exec_depend>ament_lint</exec_depend>
   <exec_depend>python3-flake8</exec_depend>
-  <!-- TODO(clalancette): enable this once it is available in RHEL-9 -->
-  <!-- <exec_depend>python3-flake8-blind-except</exec_depend> -->
+  <exec_depend>python3-flake8-blind-except</exec_depend>
   <exec_depend>python3-flake8-builtins</exec_depend>
-  <!-- TODO(clalancette): enable this once it is available in RHEL-9 -->
-  <!-- <exec_depend>python3-flake8-class-newline</exec_depend> -->
+  <exec_depend>python3-flake8-class-newline</exec_depend>
   <exec_depend>python3-flake8-comprehensions</exec_depend>
-  <!-- TODO(clalancette): enable this once it is available in RHEL-9 -->
-  <!-- <exec_depend>python3-flake8-deprecated</exec_depend> -->
+  <exec_depend>python3-flake8-deprecated</exec_depend>
   <exec_depend>python3-flake8-docstrings</exec_depend>
   <exec_depend>python3-flake8-import-order</exec_depend>
   <exec_depend>python3-flake8-quotes</exec_depend>


### PR DESCRIPTION
These are now all available on Ubuntu and RHEL, and they are in rosdep, so we can make them true dependencies now.

Once this is approved, passes CI, and merged, I'll do a release right away to get this into Rolling.