### PR TITLE
Add an ament_lint test dependency on python3-pytest. (backport #473)

### DIFF
--- a/ament_lint/package.xml
+++ b/ament_lint/package.xml
@@ -12,6 +12,8 @@
   <author>Dirk Thomas</author>
   <author>Claire Wang</author>
 
+  <test_depend>python3-pytest</test_depend>
+
   <export>
     <build_type>ament_python</build_type>
   </export>

--- a/ament_lint/setup.py
+++ b/ament_lint/setup.py
@@ -32,6 +32,7 @@ setup(
 Providing common API for ament linter packages, e.g. the `linter` marker for
 pytest.""",
     license='Apache License, Version 2.0',
+    tests_require=['pytest'],
     entry_points={
         'pytest11': [
             'ament_lint = ament_lint.pytest_marker',


### PR DESCRIPTION
Backport #473 to fix build of spaceros jazzy as per https://github.com/space-ros/space-ros/issues/218#issuecomment-2429522914

Note that the target branch should be changed to branch designated for spaceros jazzy release.