### PR TITLE
Fix ament_mypy tests return code 

### DIFF
--- a/ament_mypy/ament_mypy/main.py
+++ b/ament_mypy/ament_mypy/main.py
@@ -104,8 +104,10 @@ def main(argv: List[str] = sys.argv[1:]) -> int:
     print('\n{} files checked'.format(len(filenames)))
     if not normal_report:
         print('No errors found')
+        exit_code = 0
     else:
         print('{} errors'.format(len(errors_parsed)))
+        exit_code = len(errors_parsed)
 
     print(normal_report)
 


### PR DESCRIPTION
As mentionned in #509, main.py of ament_mypy exit code was only the return code of the executable and not the number or errors raised by it.