### PR TITLE
Improve ament_copyright performance drastically.

### DIFF
--- a/ament_copyright/ament_copyright/main.py
+++ b/ament_copyright/ament_copyright/main.py
@@ -114,7 +114,7 @@ def main(argv=sys.argv[1:]):
 
     file_descriptors = {}
     for filename in sorted(filenames):
-        file_descriptors[filename] = parse_file(filename)
+        file_descriptors[filename] = parse_file(filename, licenses, names)
 
     if args.add_missing:
         name = names.get(args.add_missing[0], args.add_missing[0])

--- a/ament_copyright/ament_copyright/parser.py
+++ b/ament_copyright/ament_copyright/parser.py
@@ -17,8 +17,6 @@ import re
 
 from ament_copyright import ALL_FILETYPES
 from ament_copyright import CONTRIBUTING_FILETYPE
-from ament_copyright import get_copyright_names
-from ament_copyright import get_licenses
 from ament_copyright import LICENSE_FILETYPE
 from ament_copyright import SOURCE_FILETYPE
 from ament_copyright import UNKNOWN_IDENTIFIER
@@ -52,14 +50,12 @@ class FileDescriptor:
         with open(self.path, 'r', encoding='utf-8') as h:
             self.content = h.read()
 
-    def parse(self):
+    def parse(self, licenses, known_copyrights):
         raise NotImplementedError()
 
-    def identify_license(self, content, license_part, licenses=None):
+    def identify_license(self, content, license_part, licenses):
         if content is None:
             return
-        if licenses is None:
-            licenses = get_licenses()
         formatted_content = remove_formatting(content)
 
         for name, license_ in licenses.items():
@@ -93,8 +89,7 @@ class SourceDescriptor(FileDescriptor):
 
         self.copyright_identifiers = []
 
-    def identify_copyright(self):
-        known_copyrights = get_copyright_names()
+    def identify_copyright(self, known_copyrights):
         for c in self.copyrights:
             found_name = c.name
             for identifier, name in known_copyrights.items():
@@ -104,7 +99,7 @@ class SourceDescriptor(FileDescriptor):
             else:
                 self.copyright_identifiers.append(UNKNOWN_IDENTIFIER)
 
-    def parse(self):
+    def parse(self, licenses, known_copyrights):
         self.read()
         if not self.content:
             return
@@ -126,10 +121,10 @@ class SourceDescriptor(FileDescriptor):
 
         self.copyrights = copyrights
 
-        self.identify_copyright()
+        self.identify_copyright(known_copyrights)
 
         content = '{copyright}' + remaining_block
-        self.identify_license(content, 'file_headers')
+        self.identify_license(content, 'file_headers', licenses)
 
 
 class ContributingDescriptor(FileDescriptor):
@@ -137,12 +132,12 @@ class ContributingDescriptor(FileDescriptor):
     def __init__(self, path):
         super(ContributingDescriptor, self).__init__(CONTRIBUTING_FILETYPE, path)
 
-    def parse(self):
+    def parse(self, licenses, known_copyrights):
         self.read()
         if not self.content:
             return
 
-        self.identify_license(self.content, 'contributing_files')
+        self.identify_license(self.content, 'contributing_files', licenses)
 
 
 class LicenseDescriptor(FileDescriptor):
@@ -150,15 +145,15 @@ class LicenseDescriptor(FileDescriptor):
     def __init__(self, path):
         super(LicenseDescriptor, self).__init__(LICENSE_FILETYPE, path)
 
-    def parse(self):
+    def parse(self, licenses, known_copyrights):
         self.read()
         if not self.content:
             return
 
-        self.identify_license(self.content, 'license_files')
+        self.identify_license(self.content, 'license_files', licenses)
 
 
-def parse_file(path):
+def parse_file(path, licenses, known_copyrights):
     filetype = determine_filetype(path)
     if filetype == SOURCE_FILETYPE:
         d = SourceDescriptor(path)
@@ -168,7 +163,7 @@ def parse_file(path):
         d = LicenseDescriptor(path)
     else:
         return None
-    d.parse()
+    d.parse(licenses, known_copyrights)
     return d
 
 

--- a/ament_copyright/ament_copyright/parser.py
+++ b/ament_copyright/ament_copyright/parser.py
@@ -17,6 +17,8 @@ import re
 
 from ament_copyright import ALL_FILETYPES
 from ament_copyright import CONTRIBUTING_FILETYPE
+from ament_copyright import get_copyright_names
+from ament_copyright import get_licenses
 from ament_copyright import LICENSE_FILETYPE
 from ament_copyright import SOURCE_FILETYPE
 from ament_copyright import UNKNOWN_IDENTIFIER
@@ -50,7 +52,7 @@ class FileDescriptor:
         with open(self.path, 'r', encoding='utf-8') as h:
             self.content = h.read()
 
-    def parse(self, licenses, known_copyrights):
+    def parse(self, licenses=None, known_copyrights=None):
         raise NotImplementedError()
 
     def identify_license(self, content, license_part, licenses):
@@ -99,7 +101,7 @@ class SourceDescriptor(FileDescriptor):
             else:
                 self.copyright_identifiers.append(UNKNOWN_IDENTIFIER)
 
-    def parse(self, licenses, known_copyrights):
+    def parse(self, licenses=None, known_copyrights=None):
         self.read()
         if not self.content:
             return
@@ -121,6 +123,11 @@ class SourceDescriptor(FileDescriptor):
 
         self.copyrights = copyrights
 
+        if licenses is None:
+            licenses = get_licenses()
+        if known_copyrights is None:
+            known_copyrights = get_copyright_names()
+
         self.identify_copyright(known_copyrights)
 
         content = '{copyright}' + remaining_block
@@ -132,10 +139,13 @@ class ContributingDescriptor(FileDescriptor):
     def __init__(self, path):
         super(ContributingDescriptor, self).__init__(CONTRIBUTING_FILETYPE, path)
 
-    def parse(self, licenses, known_copyrights):
+    def parse(self, licenses=None, known_copyrights=None):
         self.read()
         if not self.content:
             return
+
+        if licenses is None:
+            licenses = get_licenses()
 
         self.identify_license(self.content, 'contributing_files', licenses)
 
@@ -145,15 +155,23 @@ class LicenseDescriptor(FileDescriptor):
     def __init__(self, path):
         super(LicenseDescriptor, self).__init__(LICENSE_FILETYPE, path)
 
-    def parse(self, licenses, known_copyrights):
+    def parse(self, licenses=None, known_copyrights=None):
         self.read()
         if not self.content:
             return
 
+        if licenses is None:
+            licenses = get_licenses()
+
         self.identify_license(self.content, 'license_files', licenses)
 
 
-def parse_file(path, licenses, known_copyrights):
+def parse_file(path, licenses=None, known_copyrights=None):
+    if licenses is None:
+        licenses = get_licenses()
+    if known_copyrights is None:
+        known_copyrights = get_copyright_names()
+
     filetype = determine_filetype(path)
     if filetype == SOURCE_FILETYPE:
         d = SourceDescriptor(path)


### PR DESCRIPTION
While running some repeated tests locally, I was finding that ament_copyright was taking about 3 seconds to process a small number of files (34).  After looking into it, I found that it was repeatedly calling get_licenses() and get_copyright_names().

However, we notice that get_licenses() and get_copyright_names() are pulling the known copyrights from the package itself. Thus, there is no way that these can change during the runtime of the program.

This PR changes it so that we only call these functions once in main(), and the rest of the code just uses that.  With this in place, the runtime for the 34 files I was checking went from 3 seconds down to 0.2 seconds.