### PR TITLE
Fix Windows Regression by removing removesuffix()

### DIFF
--- a/ament_mypy/ament_mypy/main.py
+++ b/ament_mypy/ament_mypy/main.py
@@ -230,7 +230,8 @@ def _get_files(paths: List[str]) -> List[str]:
                         type_stub_path = os.path.join(dirpath, filename)
                         files.append(type_stub_path)
 
-                        regular_file_path = type_stub_path.removesuffix('i')
+                        # removes suffix i
+                        regular_file_path = type_stub_path[:-len('i')]
                         # Use type stub over file
                         if regular_file_path in files:
                             files.remove(regular_file_path)


### PR DESCRIPTION
removesuffix() is only available in Python3.8 +

This went throught fine on the CI running 3.12 which is why it went un caught.

Closes #523 