### PR TITLE
Enable a quiet mode for cpplint

### DIFF
--- a/ament_cpplint/ament_cpplint/main.py
+++ b/ament_cpplint/ament_cpplint/main.py
@@ -20,6 +20,8 @@ import os
 import re
 import sys
 import time
+import logging
+
 from xml.sax.saxutils import escape
 from xml.sax.saxutils import quoteattr
 
@@ -27,6 +29,13 @@ from ament_cpplint import cpplint
 from ament_cpplint.cpplint import _cpplint_state
 from ament_cpplint.cpplint import ParseArguments
 from ament_cpplint.cpplint import ProcessFile
+
+
+def setup_logging(quiet):
+    logging.basicConfig(
+            format='%(levelname)s: %(message)s', stream=sys.stdout,
+            level=logging.INFO if quiet else logging.DEBUG
+    )
 
 
 # use custom header guard with two underscore between the name parts
@@ -92,13 +101,18 @@ def main(argv=sys.argv[1:]):
         help='The files or directories to check. For directories files ending '
              'in %s will be considered.' %
              ', '.join(["'.%s'" % e for e in extensions + headers]))
+    parser.add_argument(
+        '--quiet', action='store_true',
+        help='Set logging level to debug and pass quiet arg to cpplint'
+    )
     # not using a file handle directly
     # in order to prevent leaving an empty file when something fails early
     parser.add_argument(
         '--xunit-file',
         help='Generate a xunit compliant XML file')
     args = parser.parse_args(argv)
-
+    setup_logging(quiet=args.quiet)
+    LOGGER = logging.getLogger()
     if args.xunit_file:
         start_time = time.time()
 
@@ -128,10 +142,11 @@ def main(argv=sys.argv[1:]):
     argv.append('--filter=%s' % ','.join(filters))
 
     argv.append('--linelength=%d' % args.linelength)
-
+    if args.quiet:
+        argv.append('--quiet')
     groups = get_file_groups(args.paths, extensions + headers, args.exclude)
     if not groups:
-        print('No files found', file=sys.stderr)
+        LOGGER.info('No files found')
         return 1
 
     # hook into error reporting
@@ -149,10 +164,9 @@ def main(argv=sys.argv[1:]):
         if root:
             root_arg = '--root=%s' % root
             arguments.append(root_arg)
-            print("Using '%s' argument" % root_arg)
+            LOGGER.debug("Using '%s' argument", root_arg)
         else:
-            print("Not using '--root'")
-        print('')
+            LOGGER.debug("Not using '--root'")
 
         arguments += files
         filenames = ParseArguments(arguments)
@@ -174,18 +188,15 @@ def main(argv=sys.argv[1:]):
 
             ProcessFile(filename, _cpplint_state.verbose_level)
             report.append((filename, errors))
-            print('')
 
     # output summary
     for category in sorted(_cpplint_state.errors_by_category.keys()):
         count = _cpplint_state.errors_by_category[category]
-        print("Category '%s' errors found: %d" % (category, count),
-              file=sys.stderr)
+        LOGGER.info('Category %s errors found: %d', category, count)
     if _cpplint_state.error_count:
-        print('Total errors found: %d' % _cpplint_state.error_count,
-              file=sys.stderr)
+        LOGGER.info('Total errors found: %d', _cpplint_state.error_count)
     else:
-        print('No problems found')
+        LOGGER.debug('No problems found')
 
     # generate xunit file
     if args.xunit_file:
@@ -235,9 +246,8 @@ def get_file_groups(paths, extensions, exclude_patterns):
                         if os.path.realpath(filepath) not in excludes:
                             append_file_to_group(groups, filepath)
 
-        if os.path.isfile(path):
-            if os.path.realpath(path) not in excludes:
-                append_file_to_group(groups, path)
+        if os.path.isfile(path) and os.path.realpath(path) not in excludes:
+            append_file_to_group(groups, path)
 
     return groups
 

--- a/ament_cpplint/ament_cpplint/main.py
+++ b/ament_cpplint/ament_cpplint/main.py
@@ -21,7 +21,6 @@ import os
 import re
 import sys
 import time
-
 from xml.sax.saxutils import escape
 from xml.sax.saxutils import quoteattr
 

--- a/ament_cpplint/ament_cpplint/main.py
+++ b/ament_cpplint/ament_cpplint/main.py
@@ -16,11 +16,11 @@
 
 import argparse
 import glob
+import logging
 import os
 import re
 import sys
 import time
-import logging
 
 from xml.sax.saxutils import escape
 from xml.sax.saxutils import quoteattr


### PR DESCRIPTION
Add --quiet argument to ament_cpplint to reduce output noise.
This PR introduces a --quiet flag for ament_cpplint, allowing users to suppress verbose output.
I would like to see this supported to make the output more readable, especially when many files are checked at once, currently the output is quite noisy, e.g:  [here](https://github.com/ros-navigation/navigation2/actions/runs/13910669534/job/38923996058?pr=4915).