### PR TITLE
DRAFT README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,14 @@
-# Ament Lint
-
-ament_lint integrates linting into ROS 2’s build system, automating code quality checks based on [ROS 2 coding standards](https://docs.ros.org/en/rolling/The-ROS2-Project/Contributing/Code-Style-Language-Versions.html).
+ament_lint integrates linting tools into ROS 2’s build system, automating code quality checks based on the [ROS 2 coding standards](https://docs.ros.org/en/rolling/The-ROS2-Project/Contributing/Code-Style-Language-Versions.html).
+It bundles common linting tools with ROS 2-specific wrappers to ensure consistent functionality across packages.
 
 ## Key Benefits
+- Seamless Build Integration – No manual scripting for tool setup or result parsing.
+- Preconfigured Standards – Enforces ROS 2 guidelines for C++, Python, XML, etc.
 
-- Build Integration
-- Linting runs during colcon build
-- No manual scripting for tool setup or result parsing.
+## Contributing
 
-## ROS 2 Standards
-
-Preconfigured rules to match [ros2 coding guidelines](https://docs.ros.org/en/rolling/The-ROS2-Project/Contributing/Code-Style-Language-Versions.html) for C++, Python, XML, and CMake.
-
-## Flexibility
-
-If you don't want to stick to the ros2 coding guidelines use your own configurations (e.g., ament_cppcheck(ARGS "...")) while retaining CMake integration.
-
-## Contribution
-
-In particular, the configuration of the tools is not yet perfect and not everything you are used to from the basic tools works. Feel free to contribute to this project and improve the configuration options
-Feel free two contribute to this repo, please follow the [Contrubution Guidelines](CONTRIBUTING.md).
+The tool argument are still being refined — some features from standalone linters may not yet work perfectly. We welcome contributions to improve:
+- Linter configurations
+- Additional tool support
+- ...
+Please follow the [Contrubution Guidelines](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Ament Lint
+
+ament_lint integrates linting into ROS 2’s build system, automating code quality checks based on [ROS 2 coding standards](https://docs.ros.org/en/rolling/The-ROS2-Project/Contributing/Code-Style-Language-Versions.html).
+
+## Key Benefits
+
+- Build Integration
+- Linting runs during colcon build
+- No manual scripting for tool setup or result parsing.
+
+## ROS 2 Standards
+
+Preconfigured rules to match [ros2 coding guidelines](https://docs.ros.org/en/rolling/The-ROS2-Project/Contributing/Code-Style-Language-Versions.html) for C++, Python, XML, and CMake.
+
+## Flexibility
+
+If you don't want to stick to the ros2 coding guidelines use your own configurations (e.g., ament_cppcheck(ARGS "...")) while retaining CMake integration.
+
+## Contribution
+
+In particular, the configuration of the tools is not yet perfect and not everything you are used to from the basic tools works. Feel free to contribute to this project and improve the configuration options
+Feel free two contribute to this repo, please follow the [Contrubution Guidelines](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-ament_lint integrates linting tools into ROS 2’s build system, automating code quality checks based on the [ROS 2 coding standards](https://docs.ros.org/en/rolling/The-ROS2-Project/Contributing/Code-Style-Language-Versions.html).
+ament_lint contains a number of packages that perform linting tasks. Those linters can be used both from the command line and from CMake.
+The tools are configured to meet [ROS 2 coding standards](https://docs.ros.org/en/rolling/The-ROS2-Project/Contributing/Code-Style-Language-Versions.html).
 It bundles common linting tools with ROS 2-specific wrappers to ensure consistent functionality across packages.
 
 ## Key Benefits

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
-ament_lint contains a number of packages that perform linting tasks. Those linters can be used both from the command line and from CMake.
+## ament_lint
+
+ament_lint contains a number of packages, each package wraps a linter into an ament_$linter CLI tool, which is then wrapped in CMake (ament_cmake_$linter)
+Those linters can be used both from the command line and from CMake.
 The tools are configured to meet [ROS 2 coding standards](https://docs.ros.org/en/rolling/The-ROS2-Project/Contributing/Code-Style-Language-Versions.html).
 It bundles common linting tools with ROS 2-specific wrappers to ensure consistent functionality across packages.
+Fore more information regarding ament_lint see [here](https://docs.ros.org/en/rolling/Tutorials/Advanced/Ament-Lint-For-Clean-Code.html).
+For information on each ament tool, refer to the documentation in their package's doc/ directory.
 
 ## Contributing
 
-The tool argument are still being refined — some features from standalone linters may not yet work perfectly. We welcome contributions to improve:
+We welcome contributions to improve:
 - Linter arguments
 - Additional tool support
 - ...
-Please follow the [Contrubution Guidelines](CONTRIBUTING.md).
+
+Please follow the [Contribution Guidelines](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@ ament_lint contains a number of packages that perform linting tasks. Those linte
 The tools are configured to meet [ROS 2 coding standards](https://docs.ros.org/en/rolling/The-ROS2-Project/Contributing/Code-Style-Language-Versions.html).
 It bundles common linting tools with ROS 2-specific wrappers to ensure consistent functionality across packages.
 
-## Key Benefits
-- Seamless Build Integration – No manual scripting for tool setup or result parsing.
-- Preconfigured Standards – Enforces ROS 2 guidelines for C++, Python, XML, etc.
-
 ## Contributing
 
 The tool argument are still being refined — some features from standalone linters may not yet work perfectly. We welcome contributions to improve:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It bundles common linting tools with ROS 2-specific wrappers to ensure consisten
 ## Contributing
 
 The tool argument are still being refined — some features from standalone linters may not yet work perfectly. We welcome contributions to improve:
-- Linter configurations
+- Linter arguments
 - Additional tool support
 - ...
 Please follow the [Contrubution Guidelines](CONTRIBUTING.md).


### PR DESCRIPTION
Regarding #529.
This is just a first draft for a README (Far from beeing perfect).
I would appreciate some feedback regarding the points below. 

This PR proposes an initial README to make the repository more self-contained. While minimal, it aims to:

- Clarify ament_lint’s purpose for new contributors/users.
- Explain key benefits /shortcoming over manual linting setups.
- Provide quick-start examples for common workflows (e.g. by refering the tools docs)


**I still have the following open questions which might be answered by the readme**:

- Why Not Just Share Tool Configs?
If the goal is to standardize linting, why bundle configurations with CMake integration instead of distributing standalone configs (e.g., .clang-format, flake8.ini) that developers could adopt via other tools like pre-commit?

- Abstraction Tradeoffs
While CMake integration benefits some workflows, it adds a layer that complicates debugging or customization for others. For example, developers using pre-commit might see ament_lint as more of a burdon.

- Could ament_lint focus on integration while decoupling from configuration?

- ROS Core Team’s Reasoning, e.g:
Ament_lint is the officially supported ROS 2 solution for linting because it ...


