### PR TITLE
ament_cmake_pep257: handle AMENT_LINT_AUTO_FILE_EXCLUDE

### DIFF
--- a/ament_cmake_pep257/cmake/ament_cmake_pep257_lint_hook.cmake
+++ b/ament_cmake_pep257/cmake/ament_cmake_pep257_lint_hook.cmake
@@ -15,5 +15,17 @@
 file(GLOB_RECURSE _python_files FOLLOW_SYMLINKS "*.py")
 if(_python_files)
   message(STATUS "Added test 'pep257' to check Python code against some of the docstring style conventions in PEP 257")
-  ament_pep257()
+
+  # Get exclude paths for added targets
+  set(_all_exclude "")
+  if(DEFINED ament_cmake_pep257_ADDITIONAL_EXCLUDE)
+    list(APPEND _all_exclude ${ament_cmake_pep257_ADDITIONAL_EXCLUDE})
+  endif()
+
+  if(DEFINED AMENT_LINT_AUTO_FILE_EXCLUDE)
+    list(APPEND _all_exclude ${AMENT_LINT_AUTO_FILE_EXCLUDE})
+  endif()
+
+  message(STATUS "Configured pep257 exclude dirs and/or files: ${_all_exclude}")
+  ament_pep257(EXCLUDE ${_all_exclude})
 endif()

--- a/ament_cmake_pep257/cmake/ament_pep257.cmake
+++ b/ament_cmake_pep257/cmake/ament_pep257.cmake
@@ -23,7 +23,7 @@
 # @public
 #
 function(ament_pep257)
-  cmake_parse_arguments(ARG "" "TESTNAME" "" ${ARGN})
+  cmake_parse_arguments(ARG "" "EXCLUDE;TESTNAME" "" ${ARGN})
   if(NOT ARG_TESTNAME)
     set(ARG_TESTNAME "pep257")
   endif()
@@ -35,6 +35,9 @@ function(ament_pep257)
 
   set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.xunit.xml")
   set(cmd "${ament_pep257_BIN}" "--xunit-file" "${result_file}")
+  if(ARG_EXCLUDE)
+    list(APPEND cmd "--exclude" "${ARG_EXCLUDE}")
+  endif()
   list(APPEND cmd ${ARG_UNPARSED_ARGUMENTS})
 
   file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/ament_pep257")


### PR DESCRIPTION
Fix `ament_cmake_pep257` part of #458 following guidelines from #423 (based on `ament_cmake_cpplint`).