### PR TITLE
Allow overriding clang-format version via CMake

### DIFF
--- a/ament_cmake_clang_format/cmake/ament_clang_format.cmake
+++ b/ament_cmake_clang_format/cmake/ament_clang_format.cmake
@@ -23,18 +23,27 @@
 # The 'CONFIG_FILE' argument takes priority over
 # 'ament_cmake_clang_format_CONFIG_FILE' if both are defined
 #
+# The version of clang-format being run can be overridden by specifying either
+# the argument 'CLANG_FORMAT_VERSION' or a global variable named
+# `ament_cmake_clang_format_CLANG_FORMAT_VERSION`. The argument takes priority
+# over the global variable if both are defined.
+#
 # :param TESTNAME: the name of the test, default: "clang_format"
 # :type TESTNAME: string
 # :param CONFIG_FILE: the path of the configuration file for
 #                     clang-format to consider
 # :type CONFIG_FILE: string
+# :param CLANG_FORMAT_VERSION: the version suffix appended to
+#                              "clang-format-" when determining
+#                              the executable to run
+# :type CLANG_FORMAT_VERSION: string
 # :param ARGN: the files or directories to check
 # :type ARGN: list of strings
 #
 # @public
 #
 function(ament_clang_format)
-  cmake_parse_arguments(ARG "" "TESTNAME;CONFIG_FILE" "" ${ARGN})
+  cmake_parse_arguments(ARG "" "TESTNAME;CONFIG_FILE;CLANG_FORMAT_VERSION" "" ${ARGN})
   if(NOT ARG_TESTNAME)
     set(ARG_TESTNAME "clang_format")
   endif()
@@ -51,6 +60,11 @@ function(ament_clang_format)
     list(APPEND cmd "--config" "${ARG_CONFIG_FILE}")
   elseif(DEFINED ament_cmake_clang_format_CONFIG_FILE)
     list(APPEND cmd "--config" "${ament_cmake_clang_format_CONFIG_FILE}")
+  endif()
+  if(ARG_CLANG_FORMAT_VERSION)
+    list(APPEND cmd "--clang-format-version" "${ARG_CLANG_FORMAT_VERSION}")
+  elseif(DEFINED ament_cmake_clang_format_CLANG_FORMAT_VERSION)
+    list(APPEND cmd "--clang-format-version" "${ament_cmake_clang_format_CLANG_FORMAT_VERSION}")
   endif()
 
   file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/ament_clang_format")

--- a/ament_cmake_clang_format/doc/index.rst
+++ b/ament_cmake_clang_format/doc/index.rst
@@ -34,6 +34,34 @@ How to run the check from within a CMake ament package as part of the tests?
       ament_clang_format()
     endif()
 
+To override the `clang-format` version to be used, specify the
+`CLANG_FORMAT_VERSION` argument to `ament_clang_format()`:
+
+.. code:: cmake
+
+    find_package(ament_cmake REQUIRED)
+    if(BUILD_TESTING)
+      find_package(ament_cmake_clang_format REQUIRED)
+      ament_clang_format(CLANG_FORMAT_VERSION 10)
+    endif()
+
+Alternatively, this can be specified by defining the
+`ament_cmake_clang_format_CLANG_FORMAT_VERSION` global CMake variable. This can
+be useful when the test is run indirectly, such as through `ament_lint_auto`:
+
+.. code:: cmake
+
+    find_package(ament_cmake REQUIRED)
+    if(BUILD_TESTING)
+    find_package(ament_lint_auto REQUIRED)
+    set(ament_cmake_clang_format_CLANG_FORMAT_VERSION 10)
+    ament_lint_auto_find_test_dependencies()
+    endif()
+
+The `clang-format` configuration file can be overridden in the same way using
+either the `CONFIG_FILE` argument or the `ament_cmake_clang_format_CONFIG_FILE`
+global variable.
+
 When running multiple linters as part of the CMake tests the documentation of
 the package `ament_lint_auto <https://github.com/ament/ament_lint>`_ might
 contain some useful information.


### PR DESCRIPTION
Currently, there is no convenient way to specify a version of `clang-format` to be used when it's invoked via the `ament_cmake_clang_format` wrapper. The `ament_clang_format` command exposes a `--clang-format-version` argument for this purpose, introduced in #282.

This change introduces a CMake argument and global variable as methods to specify the `--clang-format-version` flag to be passed to `ament_clang_format`. This would look like:

```cmake
find_package(ament_cmake_clang_format REQUIRED)
ament_clang_format(CLANG_FORMAT_VERSION 10)
```
or, if it's invoked via `ament_lint_auto`:
```cmake
find_package(ament_lint_auto REQUIRED)
set(ament_cmake_clang_format_CLANG_FORMAT_VERSION 10)
ament_lint_auto_find_test_dependencies()
```

This follows the same pattern as how the `--config-file` argument is exposed in CMake.