### PR TITLE
Fix setuptools deprecations

### DIFF
--- a/ament_clang_format/setup.py
+++ b/ament_clang_format/setup.py
@@ -26,7 +26,6 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
@@ -35,7 +34,11 @@ setup(
 The ability to check code against style conventions using clang-format
 and generate xUnit test result files.""",
     license='Apache License, Version 2.0, BSD',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'console_scripts': [
             'ament_clang_format = ament_clang_format.main:main',

--- a/ament_clang_tidy/setup.py
+++ b/ament_clang_tidy/setup.py
@@ -26,7 +26,6 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
@@ -35,7 +34,11 @@ setup(
 The ability to check code against style conventions using clang-tidy
 and generate xUnit test result files.""",
     license='Apache License, Version 2.0, BSD',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'console_scripts': [
             'ament_clang_tidy = ament_clang_tidy.main:main',

--- a/ament_copyright/setup.py
+++ b/ament_copyright/setup.py
@@ -26,7 +26,6 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
@@ -34,7 +33,11 @@ setup(
     long_description="""\
 The ability to check sources file for copyright and license information.""",
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'ament_copyright.copyright_name': [
             'osrf = ament_copyright.copyright_names:osrf',

--- a/ament_cppcheck/setup.py
+++ b/ament_cppcheck/setup.py
@@ -23,7 +23,6 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
@@ -32,7 +31,11 @@ setup(
 The ability to perform static code analysis on C/C++ code using Cppcheck
 and generate xUnit test result files.""",
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'console_scripts': [
             'ament_cppcheck = ament_cppcheck.main:main',

--- a/ament_cpplint/setup.py
+++ b/ament_cpplint/setup.py
@@ -23,7 +23,6 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
@@ -32,7 +31,11 @@ setup(
 The ability to check code against the Google style conventions using
 cpplint and generate xUnit test result files.""",
     license='Apache License, Version 2.0, BSD',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'console_scripts': [
             'ament_cpplint = ament_cpplint.main:main',

--- a/ament_flake8/setup.py
+++ b/ament_flake8/setup.py
@@ -26,7 +26,6 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
@@ -34,7 +33,11 @@ setup(
     long_description="""\
 The ability to check code for syntax and style conventions with flake8.""",
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'console_scripts': [
             'ament_flake8 = ament_flake8.main:main',

--- a/ament_lint/setup.py
+++ b/ament_lint/setup.py
@@ -23,7 +23,6 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
@@ -32,7 +31,11 @@ setup(
 Providing common API for ament linter packages, e.g. the `linter` marker for
 pytest.""",
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'pytest11': [
             'ament_lint = ament_lint.pytest_marker',

--- a/ament_lint_cmake/setup.py
+++ b/ament_lint_cmake/setup.py
@@ -23,7 +23,6 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
@@ -32,7 +31,11 @@ setup(
 The ability to lint CMake code using cmakelint and generate xUnit test
 result files.""",
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'console_scripts': [
             'ament_lint_cmake = ament_lint_cmake.main:main',

--- a/ament_mypy/setup.py
+++ b/ament_mypy/setup.py
@@ -26,7 +26,6 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
@@ -34,7 +33,11 @@ setup(
     long_description="""\
 The ability to check code for user specified static typing with mypy.""",
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'console_scripts': [
             'ament_mypy = ament_mypy.main:main',

--- a/ament_pclint/setup.py
+++ b/ament_pclint/setup.py
@@ -53,7 +53,11 @@ setup(
 The ability to perform static code analysis on C/C++ code using PC-lint
 and generate xUnit test result files.""",
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     test_suite='test',
     entry_points={
         'console_scripts': [

--- a/ament_pep257/setup.py
+++ b/ament_pep257/setup.py
@@ -26,7 +26,6 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
@@ -35,7 +34,11 @@ setup(
 The ability to check code against the docstring conventions in PEP 257
 and generate xUnit test result files.""",
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'console_scripts': [
             'ament_pep257 = ament_pep257.main:main',

--- a/ament_pycodestyle/setup.py
+++ b/ament_pycodestyle/setup.py
@@ -26,7 +26,6 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
@@ -35,7 +34,11 @@ setup(
 The ability to check code against the style conventions in PEP 8 and
 generate xUnit test result files.""",
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'console_scripts': [
             'ament_pycodestyle = ament_pycodestyle.main:main',

--- a/ament_pyflakes/setup.py
+++ b/ament_pyflakes/setup.py
@@ -23,7 +23,6 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
@@ -32,7 +31,11 @@ setup(
 The ability to check code using pyflakes and generate xUnit test
 result files.""",
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'console_scripts': [
             'ament_pyflakes = ament_pyflakes.main:main',

--- a/ament_uncrustify/setup.py
+++ b/ament_uncrustify/setup.py
@@ -27,7 +27,6 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
@@ -36,7 +35,11 @@ setup(
 The ability to check code against style conventions using uncrustify
 and generate xUnit test result files.""",
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'console_scripts': [
             'ament_uncrustify = ament_uncrustify.main:main',

--- a/ament_xmllint/setup.py
+++ b/ament_xmllint/setup.py
@@ -23,7 +23,6 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
@@ -32,7 +31,11 @@ setup(
 The ability to check XML files like the package manifest using xmllint
 and generate xUnit test result files.""",
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'console_scripts': [
             'ament_xmllint = ament_xmllint.main:main',


### PR DESCRIPTION
fix setuptools deprecations
FIX:

#UserWarning: Unknown distribution option: 'tests_require'

and

#SetuptoolsDeprecationWarning: License classifiers are deprecated. !!

******************************************************************************** Please consider removing the following classifiers in favor of a SPDX license expression:

License :: OSI Approved :: Apache Software License

See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details. ********************************************************************************