### PR TITLE
Use negative indenting for access specifiers

### DIFF
--- a/ament_uncrustify/ament_uncrustify/configuration/ament_code_style_0_72.cfg
+++ b/ament_uncrustify/ament_uncrustify/configuration/ament_code_style_0_72.cfg
@@ -900,7 +900,7 @@ indent_col1_comment             = false    # false/true
 indent_label                    = 1        # number
 
 # Same as indent_label, but for access specifiers that are followed by a colon. Default=1
-indent_access_spec              = 1        # number
+indent_access_spec              = -indent_columns    # number
 
 # Indent the code after an access specifier by one level.
 # If set, this option forces 'indent_access_spec=0'.

--- a/ament_uncrustify/ament_uncrustify/configuration/ament_code_style_0_78.cfg
+++ b/ament_uncrustify/ament_uncrustify/configuration/ament_code_style_0_78.cfg
@@ -1432,7 +1432,7 @@ indent_label                    = 1        # number
 # <=0: Subtract from brace indent
 #
 # Default: 1
-indent_access_spec              = 1        # number
+indent_access_spec              = -indent_columns    # number
 
 # Whether to indent the code after an access specifier by one level.
 # If true, this option forces 'indent_access_spec=0'.


### PR DESCRIPTION
In order to get correct indentation of access specifiers in nested classes, the negative of the indent_columns value is used instead of the absolute leftmost column.