### PR TITLE
Revert "Removed uncrustify_vendor"

### DIFF
--- a/ament_uncrustify/package.xml
+++ b/ament_uncrustify/package.xml
@@ -18,7 +18,7 @@
   <author>Dirk Thomas</author>
   <author email="michel@ekumenlabs.com">Michel Hidalgo</author>
 
-  <exec_depend>uncrustify</exec_depend>
+  <exec_depend>uncrustify_vendor</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>


### PR DESCRIPTION
- This PR reverts ament/ament_lint#556 because it broke RHEL CI build