### PR TITLE
Remove `importlib_metadata`

### DIFF
--- a/ament_copyright/ament_copyright/__init__.py
+++ b/ament_copyright/ament_copyright/__init__.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import importlib.metadata as importlib_metadata
-except ModuleNotFoundError:
-    import importlib_metadata
+from importlib import metadata
 
 
 COPYRIGHT_GROUP = 'ament_copyright.copyright_name'
@@ -38,11 +35,8 @@ UNKNOWN_IDENTIFIER = '<unknown>'
 
 def get_copyright_names():
     names = {}
-    entry_points = importlib_metadata.entry_points()
-    if hasattr(entry_points, 'select'):
-        copyright_groups = entry_points.select(group=COPYRIGHT_GROUP)
-    else:
-        copyright_groups = entry_points.get(COPYRIGHT_GROUP, [])
+    entry_points = metadata.entry_points()
+    copyright_groups = entry_points.select(group=COPYRIGHT_GROUP)
     for entry_point in copyright_groups:
         assert entry_point.name != UNKNOWN_IDENTIFIER, \
             "Invalid entry point name '%s'" % entry_point.name
@@ -53,11 +47,8 @@ def get_copyright_names():
 
 def get_licenses():
     licenses = {}
-    entry_points = importlib_metadata.entry_points()
-    if hasattr(entry_points, 'select'):
-        license_groups = entry_points.select(group=LICENSE_GROUP)
-    else:
-        license_groups = entry_points.get(LICENSE_GROUP, [])
+    entry_points = metadata.entry_points()
+    license_groups = entry_points.select(group=LICENSE_GROUP)
     for entry_point in license_groups:
         assert entry_point.name != UNKNOWN_IDENTIFIER, \
             "Invalid entry point name '%s'" % entry_point.name

--- a/ament_copyright/ament_copyright/__init__.py
+++ b/ament_copyright/ament_copyright/__init__.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 from importlib import metadata
+import sys
 
 
 COPYRIGHT_GROUP = 'ament_copyright.copyright_name'

--- a/ament_copyright/ament_copyright/__init__.py
+++ b/ament_copyright/ament_copyright/__init__.py
@@ -40,7 +40,7 @@ def get_copyright_names():
     if sys.version_info >= (3, 12):
         copyright_groups = entry_points.select(group=COPYRIGHT_GROUP)
     else:
-        copyright_groups = entry_points.get(COPYRIGHT_GROUP)
+        copyright_groups = entry_points.get(COPYRIGHT_GROUP, [])
     for entry_point in copyright_groups:
         assert entry_point.name != UNKNOWN_IDENTIFIER, \
             "Invalid entry point name '%s'" % entry_point.name
@@ -53,9 +53,9 @@ def get_licenses():
     licenses = {}
     entry_points = metadata.entry_points()
     if sys.version_info >= (3, 12):
-        license_groups = entry_points.select(group=COPYRIGHT_GROUP)
+        license_groups = entry_points.select(group=LICENSE_GROUP)
     else:
-        license_groups = entry_points.get(COPYRIGHT_GROUP)
+        license_groups = entry_points.get(LICENSE_GROUP, [])
     for entry_point in license_groups:
         assert entry_point.name != UNKNOWN_IDENTIFIER, \
             "Invalid entry point name '%s'" % entry_point.name

--- a/ament_copyright/ament_copyright/__init__.py
+++ b/ament_copyright/ament_copyright/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 from importlib import metadata
 
 
@@ -36,7 +37,10 @@ UNKNOWN_IDENTIFIER = '<unknown>'
 def get_copyright_names():
     names = {}
     entry_points = metadata.entry_points()
-    copyright_groups = entry_points.select(group=COPYRIGHT_GROUP)
+    if sys.version_info >= (3, 12):
+        copyright_groups = entry_points.select(group=COPYRIGHT_GROUP)
+    else:
+        copyright_groups = entry_points.get(COPYRIGHT_GROUP)
     for entry_point in copyright_groups:
         assert entry_point.name != UNKNOWN_IDENTIFIER, \
             "Invalid entry point name '%s'" % entry_point.name
@@ -48,7 +52,10 @@ def get_copyright_names():
 def get_licenses():
     licenses = {}
     entry_points = metadata.entry_points()
-    license_groups = entry_points.select(group=LICENSE_GROUP)
+    if sys.version_info >= (3, 12):
+        license_groups = entry_points.select(group=COPYRIGHT_GROUP)
+    else:
+        license_groups = entry_points.get(COPYRIGHT_GROUP)
     for entry_point in license_groups:
         assert entry_point.name != UNKNOWN_IDENTIFIER, \
             "Invalid entry point name '%s'" % entry_point.name

--- a/ament_copyright/package.xml
+++ b/ament_copyright/package.xml
@@ -19,7 +19,6 @@
   <author email="michel@ekumenlabs.com">Michel Hidalgo</author>
 
   <exec_depend>ament_lint</exec_depend>
-  <exec_depend>python3-importlib-metadata</exec_depend>
 
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>


### PR DESCRIPTION
`importlib_metadata` was used to backport features to `Python3.8<` and the rolling minimum is 3.9 so we should be able  to prune it as far as I understand.