### PR TITLE
Drop setuptools from install_requires

### DIFF
--- a/ament_clang_format/setup.py
+++ b/ament_clang_format/setup.py
@@ -12,7 +12,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
-    install_requires=['setuptools', 'pyyaml'],
+    install_requires=['pyyaml'],
     package_data={'': [
         'configuration/.clang-format',
         'py.typed'

--- a/ament_clang_tidy/setup.py
+++ b/ament_clang_tidy/setup.py
@@ -12,7 +12,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
-    install_requires=['setuptools', 'pyyaml'],
+    install_requires=['pyyaml'],
     package_data={'': [
         'configuration/.clang-tidy',
         'py.typed'

--- a/ament_copyright/setup.py
+++ b/ament_copyright/setup.py
@@ -12,7 +12,6 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
-    install_requires=['setuptools'],
     package_data={'': [
         'template/*',
         'py.typed'

--- a/ament_cppcheck/setup.py
+++ b/ament_cppcheck/setup.py
@@ -13,7 +13,6 @@ setup(
             ['resource/' + package_name]),
     ],
     package_data={'': ['py.typed']},
-    install_requires=['setuptools'],
     zip_safe=True,
     author='Dirk Thomas',
     author_email='dthomas@osrfoundation.org',

--- a/ament_cpplint/setup.py
+++ b/ament_cpplint/setup.py
@@ -13,7 +13,6 @@ setup(
             ['resource/' + package_name]),
     ],
     package_data={'': ['py.typed']},
-    install_requires=['setuptools'],
     zip_safe=True,
     author='Dirk Thomas',
     author_email='dthomas@osrfoundation.org',

--- a/ament_flake8/setup.py
+++ b/ament_flake8/setup.py
@@ -12,7 +12,6 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
-    install_requires=['setuptools'],
     package_data={'': [
         'configuration/ament_flake8.ini',
         'py.typed'

--- a/ament_lint/setup.py
+++ b/ament_lint/setup.py
@@ -13,7 +13,6 @@ setup(
             ['resource/' + package_name]),
     ],
     package_data={'': ['py.typed']},
-    install_requires=['setuptools'],
     zip_safe=True,
     author='Dirk Thomas',
     author_email='dthomas@osrfoundation.org',

--- a/ament_lint_cmake/setup.py
+++ b/ament_lint_cmake/setup.py
@@ -13,7 +13,6 @@ setup(
             ['resource/' + package_name]),
     ],
     package_data={'': ['py.typed']},
-    install_requires=['setuptools'],
     zip_safe=True,
     author='Dirk Thomas',
     author_email='dthomas@osrfoundation.org',

--- a/ament_mypy/setup.py
+++ b/ament_mypy/setup.py
@@ -12,7 +12,6 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
-    install_requires=['setuptools'],
     package_data={'': [
         'configuration/ament_mypy.ini',
         'py.typed'

--- a/ament_pclint/setup.py
+++ b/ament_pclint/setup.py
@@ -12,7 +12,6 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
-    install_requires=['setuptools'],
     package_data={'': [
         'config/gcc/co-g++.h',
         'config/gcc/co-g++.lnt',

--- a/ament_pep257/setup.py
+++ b/ament_pep257/setup.py
@@ -12,7 +12,6 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
-    install_requires=['setuptools'],
     package_data={'': [
         'configuration/ament_pep257.ini',
         'py.typed'

--- a/ament_pycodestyle/setup.py
+++ b/ament_pycodestyle/setup.py
@@ -12,7 +12,6 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
-    install_requires=['setuptools'],
     package_data={'': [
         'configuration/ament_pycodestyle.ini',
         'py.typed'

--- a/ament_pyflakes/setup.py
+++ b/ament_pyflakes/setup.py
@@ -13,7 +13,6 @@ setup(
             ['resource/' + package_name]),
     ],
     package_data={'': ['py.typed']},
-    install_requires=['setuptools'],
     zip_safe=True,
     author='Dirk Thomas',
     author_email='dthomas@osrfoundation.org',

--- a/ament_uncrustify/setup.py
+++ b/ament_uncrustify/setup.py
@@ -12,7 +12,6 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
-    install_requires=['setuptools'],
     package_data={'': [
         'configuration/ament_code_style_0_72.cfg',
         'configuration/ament_code_style_0_78.cfg',

--- a/ament_xmllint/setup.py
+++ b/ament_xmllint/setup.py
@@ -13,7 +13,6 @@ setup(
             ['resource/' + package_name]),
     ],
     package_data={'': ['py.typed']},
-    install_requires=['setuptools'],
     zip_safe=True,
     author='Dirk Thomas',
     author_email='dthomas@osrfoundation.org',


### PR DESCRIPTION
Non of the packages import setuptools at runtime. This is probably a
leftover from the pkg_resources removal in 0.10.0.