### PR TITLE
[ament_mypy] Add `--ament-strict` flag for more strict type checking.

### DIFF
--- a/ament_cmake_mypy/cmake/ament_mypy.cmake
+++ b/ament_cmake_mypy/cmake/ament_mypy.cmake
@@ -25,9 +25,14 @@
 # @public
 #
 function(ament_mypy)
-  cmake_parse_arguments(ARG "" "CONFIG_FILE;TESTNAME" "" ${ARGN})
+  cmake_parse_arguments(ARG "" "CONFIG_FILE;TESTNAME;AMENT_STRICT" "" ${ARGN})
   if(NOT ARG_TESTNAME)
     set(ARG_TESTNAME "mypy")
+  endif()
+
+  # Error if both CONFIG_FILE and AMENT_STRICT are provided
+  if(ARG_CONFIG_FILE AND ARG_AMENT_STRICT)
+    message(FATAL_ERROR "ament_mypy(): Cannot specify both CONFIG_FILE and AMENT_STRICT at the same time")
   endif()
 
   find_program(ament_mypy_BIN NAMES "ament_mypy")
@@ -40,6 +45,11 @@ function(ament_mypy)
   if(ARG_CONFIG_FILE)
     list(APPEND cmd "--config" "${ARG_CONFIG_FILE}")
   endif()
+
+  if(ARG_AMENT_STRICT)
+    list(APPEND cmd "--ament-strict")
+  endif()
+
   list(APPEND cmd ${ARG_UNPARSED_ARGUMENTS})
 
   file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/ament_mypy")

--- a/ament_cmake_mypy/cmake/ament_mypy.cmake
+++ b/ament_cmake_mypy/cmake/ament_mypy.cmake
@@ -15,6 +15,8 @@
 #
 # Add a test to statically check Python types using mypy.
 #
+# :option AMENT_STRICT: Wether to run in strict mode. Excluse with CONFIG_FILE
+# :type AMENT_STRICT: bool 
 # :param CONFIG_FILE: the name of the config file to use, if any
 # :type CONFIG_FILE: string
 # :param TESTNAME: the name of the test, default: "mypy"
@@ -25,7 +27,7 @@
 # @public
 #
 function(ament_mypy)
-  cmake_parse_arguments(ARG "" "CONFIG_FILE;TESTNAME;AMENT_STRICT" "" ${ARGN})
+  cmake_parse_arguments(ARG "AMENT_STRICT" "CONFIG_FILE;TESTNAME" "" ${ARGN})
   if(NOT ARG_TESTNAME)
     set(ARG_TESTNAME "mypy")
   endif()

--- a/ament_cmake_mypy/cmake/ament_mypy.cmake
+++ b/ament_cmake_mypy/cmake/ament_mypy.cmake
@@ -16,7 +16,7 @@
 # Add a test to statically check Python types using mypy.
 #
 # :option AMENT_STRICT: Wether to run in strict mode. Excluse with CONFIG_FILE
-# :type AMENT_STRICT: bool 
+# :type AMENT_STRICT: bool
 # :param CONFIG_FILE: the name of the config file to use, if any
 # :type CONFIG_FILE: string
 # :param TESTNAME: the name of the test, default: "mypy"

--- a/ament_flake8/ament_flake8/main.py
+++ b/ament_flake8/ament_flake8/main.py
@@ -18,6 +18,7 @@ import argparse
 import os
 import sys
 import time
+from typing import Literal
 from xml.sax.saxutils import escape
 from xml.sax.saxutils import quoteattr
 
@@ -27,12 +28,12 @@ from flake8.main import application as flake8_app
 from flake8.main import options as flake8_options
 
 
-def main(argv=sys.argv[1:]):
+def main(argv: list[str] = sys.argv[1:]) -> Literal[0, 1]:
     rc, _ = main_with_errors(argv=argv)
     return rc
 
 
-def main_with_errors(argv=sys.argv[1:]):
+def main_with_errors(argv: list[str] = sys.argv[1:]) -> tuple[Literal[0, 1], list[str]]:
     config_file = os.path.join(
         os.path.dirname(__file__), 'configuration', 'ament_flake8.ini')
 

--- a/ament_flake8/ament_flake8/pytest_marker.py
+++ b/ament_flake8/ament_flake8/pytest_marker.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pytest import Config
 
-def pytest_configure(config):
+
+def pytest_configure(config: Config) -> None:
     config.addinivalue_line(
         'markers', 'flake8: marks tests checking for flake8 compliance')

--- a/ament_flake8/ament_flake8/pytest_marker.py
+++ b/ament_flake8/ament_flake8/pytest_marker.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pytest import Config
+
+from _pytest.config import Config
 
 
 def pytest_configure(config: Config) -> None:

--- a/ament_mypy/ament_mypy/configuration/ament_mypy_strict.toml
+++ b/ament_mypy/ament_mypy/configuration/ament_mypy_strict.toml
@@ -1,0 +1,4 @@
+[tool.mypy]
+
+strict = true
+pretty = true

--- a/ament_mypy/ament_mypy/configuration/ament_mypy_strict.toml
+++ b/ament_mypy/ament_mypy/configuration/ament_mypy_strict.toml
@@ -1,4 +1,8 @@
 [tool.mypy]
-
 strict = true
 pretty = true
+
+# Done until rhel has types-setuptools
+[[tool.mypy.overrides]]
+module = "setup"
+ignore_errors = true

--- a/ament_mypy/ament_mypy/main.py
+++ b/ament_mypy/ament_mypy/main.py
@@ -33,13 +33,32 @@ def main(argv: List[str] = sys.argv[1:]) -> int:
         description='Check code using mypy',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
-    parser.add_argument(
+
+    config_group = parser.add_mutually_exclusive_group()
+    config_group.add_argument(
         '--config',
         metavar='path',
         dest='config_file',
-        default=os.path.join(os.path.dirname(__file__), 'configuration', 'ament_mypy.ini'),
-        help='The config file'
+        default=os.path.join(
+            os.path.dirname(__file__),
+            'configuration',
+            'ament_mypy.ini',
+        ),
+        help='The config file',
     )
+
+    config_group.add_argument(
+        '--ament-strict',
+        action='store_const',
+        dest='config_file',
+        const=os.path.join(
+            os.path.dirname(__file__),
+            'configuration',
+            'ament_mypy_strict.toml',
+        ),
+        help='Use strict ament mypy configuration',
+    )
+
     parser.add_argument(
         'paths',
         nargs='*',
@@ -137,7 +156,7 @@ def main(argv: List[str] = sys.argv[1:]) -> int:
 def _generate_mypy_report(paths: List[str],
                           config_file: Optional[str] = None,
                           cache_dir: str = os.devnull) -> Tuple[str, str, int]:
-    mypy_argv = []
+    mypy_argv: list[str] = []
     mypy_argv.append('--cache-dir')
     mypy_argv.append(str(cache_dir))
     if cache_dir == os.devnull:

--- a/ament_mypy/ament_mypy/pytest_marker.py
+++ b/ament_mypy/ament_mypy/pytest_marker.py
@@ -11,7 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from _pytest.config import Config
+
+from pytest import Config
 
 
 def pytest_configure(config: Config) -> None:

--- a/ament_mypy/ament_mypy/pytest_marker.py
+++ b/ament_mypy/ament_mypy/pytest_marker.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pytest import Config
+
+from _pytest.config import Config
 
 
 def pytest_configure(config: Config) -> None:

--- a/ament_mypy/setup.py
+++ b/ament_mypy/setup.py
@@ -14,7 +14,7 @@ setup(
     ],
     package_data={'': [
         'configuration/ament_mypy.ini',
-        'configuration/ament_mypy_strict.toml'
+        'configuration/ament_mypy_strict.toml',
         'py.typed'
     ]},
     zip_safe=False,

--- a/ament_mypy/setup.py
+++ b/ament_mypy/setup.py
@@ -14,6 +14,7 @@ setup(
     ],
     package_data={'': [
         'configuration/ament_mypy.ini',
+        'configuration/ament_mypy_strict.toml'
         'py.typed'
     ]},
     zip_safe=False,

--- a/ament_mypy/test/test_ament_mypy.py
+++ b/ament_mypy/test/test_ament_mypy.py
@@ -2,11 +2,10 @@ import os
 from pathlib import Path
 import xml.etree.ElementTree as ET
 
+from _pytest.tmpdir import TempPathFactory
 import ament_mypy.main
-
 import pytest
-from pytest import TempPathFactory
-from pytest_mock import MockerFixture
+from pytest_mock.plugin import MockerFixture
 from pytest_mock.plugin import MockType
 
 

--- a/ament_mypy/test/test_ament_mypy.py
+++ b/ament_mypy/test/test_ament_mypy.py
@@ -1,12 +1,12 @@
 import os
 from pathlib import Path
+from unittest.mock import MagicMock
 import xml.etree.ElementTree as ET
 
 from _pytest.tmpdir import TempPathFactory
 import ament_mypy.main
 import pytest
 from pytest_mock.plugin import MockerFixture
-from pytest_mock.plugin import MockType
 
 
 @pytest.fixture()
@@ -57,7 +57,7 @@ def ignore_dir(tmp_path_factory: TempPathFactory) -> Path:
 
 
 @pytest.fixture()
-def mock_mypy_succ(mocker: MockerFixture) -> MockType:
+def mock_mypy_succ(mocker: MockerFixture) -> MagicMock:
     return mocker.patch('ament_mypy.main.mypy.api.run', return_value=('', '', 0))
 
 
@@ -73,18 +73,18 @@ def sample_errors(use_dir: Path) -> list[str]:
 
 
 @pytest.fixture()
-def mock_mypy_generate_fail(mocker: MockerFixture, sample_errors: list[str]) -> MockType:
+def mock_mypy_generate_fail(mocker: MockerFixture, sample_errors: list[str]) -> MagicMock:
     mock_fail = mocker.patch('ament_mypy.main._generate_mypy_report')
     mock_fail.return_value = ('\n'.join(sample_errors), '', 1)
     return mock_fail
 
 
 @pytest.fixture()
-def mock_generate_report(mocker: MockerFixture) -> MockType:
+def mock_generate_report(mocker: MockerFixture) -> MagicMock:
     return mocker.patch('ament_mypy.main._generate_mypy_report')
 
 
-def test__generate_mypy_report(mock_mypy_succ: MockType) -> None:
+def test__generate_mypy_report(mock_mypy_succ: MagicMock) -> None:
     # Test if correctly returns mypy output
     files = ['a.py', 'b.py']
     assert ament_mypy.main._generate_mypy_report(files) == mock_mypy_succ.return_value
@@ -119,7 +119,7 @@ def test__generate_mypy_report(mock_mypy_succ: MockType) -> None:
     assert '--no-incremental' not in args[0]
 
 
-def test_main_success(mock_generate_report: MockType, use_dir: Path) -> None:
+def test_main_success(mock_generate_report: MagicMock, use_dir: Path) -> None:
     mock_generate_report.return_value = ('', '', 0)
 
     # Test that a successful lint returns 0
@@ -142,7 +142,7 @@ def test_main_success(mock_generate_report: MockType, use_dir: Path) -> None:
     assert str(use_dir / '03.txt') not in args[0]
 
 
-def test_main_exclude(mock_generate_report: MockType, use_dir: Path) -> None:
+def test_main_exclude(mock_generate_report: MagicMock, use_dir: Path) -> None:
     mock_generate_report.return_value = ('', '', 0)
     # Test that excluding a file that was passed as an arg works
     assert ament_mypy.main.main([str(use_dir / '01.py'),
@@ -165,14 +165,14 @@ def test_main_exclude(mock_generate_report: MockType, use_dir: Path) -> None:
     mock_generate_report.assert_not_called()
 
 
-def test_ignore(mock_generate_report: MockType, use_dir: Path, ignore_dir: Path) -> None:
+def test_ignore(mock_generate_report: MagicMock, use_dir: Path, ignore_dir: Path) -> None:
     mock_generate_report.return_value = ('', '', 0)
 
     # Test if returns no error if at least one valid dir is presented
     assert ament_mypy.main.main([str(use_dir), str(ignore_dir)]) == 0
 
 
-def test_fail(mocker: MockerFixture, mock_mypy_generate_fail: MockType, use_dir: Path) -> None:
+def test_fail(mocker: MockerFixture, mock_mypy_generate_fail: MagicMock, use_dir: Path) -> None:
     # Test if an error message from mypy causes a non-zero return
     assert ament_mypy.main.main([str(use_dir / '01.py')])
 
@@ -198,7 +198,7 @@ def test_main_error(mocker: MockerFixture, use_dir: Path) -> None:
     assert ament_mypy.main.main([str(use_dir)]) == 15
 
 
-def test_main_config_file(mock_generate_report: MockType, mocker: MockerFixture,
+def test_main_config_file(mock_generate_report: MagicMock, mocker: MockerFixture,
                           use_dir: Path) -> None:
     # Test that a valid config file is passed on to mypy
     conf_file = use_dir / 'mypy.ini'
@@ -220,7 +220,7 @@ def test_main_config_file(mock_generate_report: MockType, mocker: MockerFixture,
                                  str(use_dir / 'aeiou.ini')]) == 1
 
 
-def test_main_xunit(mock_mypy_generate_fail: MockType, mocker: MockerFixture,
+def test_main_xunit(mock_mypy_generate_fail: MagicMock, mocker: MockerFixture,
                     use_dir: Path) -> None:
     mock_xunit = mocker.patch('ament_mypy.main._get_xunit_content')
     mock_xunit.return_value = "<?xml version='1.0' encoding='UTF-8'?></xml>\n"

--- a/ament_mypy/test/test_ament_mypy.py
+++ b/ament_mypy/test/test_ament_mypy.py
@@ -5,10 +5,13 @@ import xml.etree.ElementTree as ET
 import ament_mypy.main
 
 import pytest
+from pytest import TempPathFactory
+from pytest_mock import MockerFixture
+from pytest_mock.plugin import MockType
 
 
 @pytest.fixture()
-def use_dir(tmpdir_factory):
+def use_dir(tmp_path_factory: TempPathFactory) -> Path:
     """Create a sample data directory for testing.
 
     Directory layout::
@@ -20,17 +23,18 @@ def use_dir(tmpdir_factory):
         +-- 03.txt
 
     """
-    use_me = tmpdir_factory.mktemp('use_me')
-    files = [use_me.join(arg) for arg in ['01.py', '02.py', '03.txt']]
-    files.append(use_me.join('me_too', '03.py'))
+    use_me = tmp_path_factory.mktemp('use_me')
+    files = [use_me / arg for arg in ['01.py', '02.py', '03.txt']]
+    files.append(use_me / 'me_too' / '03.py')
 
     for tmp_file in files:
-        tmp_file.write('', ensure=True)
+        tmp_file.parent.mkdir(parents=True, exist_ok=True)
+        tmp_file.write_text('')
     return use_me
 
 
 @pytest.fixture()
-def ignore_dir(tmpdir_factory):
+def ignore_dir(tmp_path_factory: TempPathFactory) -> Path:
     """Create a sample data directory for testing.
 
     Directory layout::
@@ -43,24 +47,25 @@ def ignore_dir(tmpdir_factory):
         +-- AMENT_IGNORE
 
     """
-    ignore_me = tmpdir_factory.mktemp('ignore_me')
-    files = [ignore_me.join(arg) for arg in ['01.py', '02.py', '03.txt', 'AMENT_IGNORE']]
-    files.append(ignore_me.join('me_too', '03.py'))
+    ignore_me = tmp_path_factory.mktemp('ignore_me')
+    files = [ignore_me / arg for arg in ['01.py', '02.py', '03.txt', 'AMENT_IGNORE']]
+    files.append(ignore_me / 'me_too' / '03.py')
 
     for tmp_file in files:
-        tmp_file.write('', ensure=True)
+        tmp_file.parent.mkdir(parents=True, exist_ok=True)
+        tmp_file.write_text('')
     return ignore_me
 
 
 @pytest.fixture()
-def mock_mypy_succ(mocker):
+def mock_mypy_succ(mocker: MockerFixture) -> MockType:
     return mocker.patch('ament_mypy.main.mypy.api.run', return_value=('', '', 0))
 
 
 @pytest.fixture()
-def sample_errors(use_dir):
-    def filename(slug: str):
-        return str(use_dir.join(slug))
+def sample_errors(use_dir: Path) -> list[str]:
+    def filename(slug: str) -> str:
+        return str(use_dir / slug)
     error_line_col = '{}:0:0: error: error message'.format(filename('lc.py'))
     error_line = '{}:0: error: error message'.format(filename('l.py'))
     error_no_pos = '{}: error: error message'.format(filename('no_pos.py'))
@@ -69,18 +74,18 @@ def sample_errors(use_dir):
 
 
 @pytest.fixture()
-def mock_mypy_generate_fail(mocker, sample_errors, use_dir):
+def mock_mypy_generate_fail(mocker: MockerFixture, sample_errors: list[str]) -> MockType:
     mock_fail = mocker.patch('ament_mypy.main._generate_mypy_report')
     mock_fail.return_value = ('\n'.join(sample_errors), '', 1)
     return mock_fail
 
 
 @pytest.fixture()
-def mock_generate_report(mocker):
+def mock_generate_report(mocker: MockerFixture) -> MockType:
     return mocker.patch('ament_mypy.main._generate_mypy_report')
 
 
-def test__generate_mypy_report(mock_mypy_succ):
+def test__generate_mypy_report(mock_mypy_succ: MockType) -> None:
     # Test if correctly returns mypy output
     files = ['a.py', 'b.py']
     assert ament_mypy.main._generate_mypy_report(files) == mock_mypy_succ.return_value
@@ -115,45 +120,45 @@ def test__generate_mypy_report(mock_mypy_succ):
     assert '--no-incremental' not in args[0]
 
 
-def test_main_success(mock_generate_report, use_dir):
+def test_main_success(mock_generate_report: MockType, use_dir: Path) -> None:
     mock_generate_report.return_value = ('', '', 0)
 
     # Test that a successful lint returns 0
-    assert ament_mypy.main.main([str(use_dir.join('01.py'))]) == 0
+    assert ament_mypy.main.main([str(use_dir / '01.py')]) == 0
 
     # Sub-test that no other files in directory were checked, too
     args, _ = mock_generate_report.call_args
-    assert str(use_dir.join('01.py')) in args[0]
-    assert str(use_dir.join('02.py')) not in args[0]
-    assert str(use_dir.join('03.txt')) not in args[0]
+    assert str(use_dir / '01.py') in args[0]
+    assert str(use_dir / '02.py') not in args[0]
+    assert str(use_dir / '03.txt') not in args[0]
 
     # Test that a directory recursively is checked
     assert ament_mypy.main.main([str(use_dir)]) == 0
     args, _ = mock_generate_report.call_args
-    assert str(use_dir.join('01.py')) in args[0]
-    assert str(use_dir.join('02.py')) in args[0]
-    assert str(use_dir.join('03.py')) not in args[0]
+    assert str(use_dir / '01.py') in args[0]
+    assert str(use_dir / '02.py') in args[0]
+    assert str(use_dir / '03.py') not in args[0]
 
     # Test that non-'.py' files were ignored
-    assert str(use_dir.join('03.txt')) not in args[0]
+    assert str(use_dir / '03.txt') not in args[0]
 
 
-def test_main_exclude(mock_generate_report, use_dir):
+def test_main_exclude(mock_generate_report: MockType, use_dir: Path) -> None:
     mock_generate_report.return_value = ('', '', 0)
     # Test that excluding a file that was passed as an arg works
-    assert ament_mypy.main.main([str(use_dir.join('01.py')),
-                                 str(use_dir.join('02.py')),
+    assert ament_mypy.main.main([str(use_dir / '01.py'),
+                                 str(use_dir / '02.py'),
                                  '--exclude',
                                  '02.py']) == 0
     args, _ = mock_generate_report.call_args
-    assert str(use_dir.join('01.py')) in args[0]
-    assert str(use_dir.join('02.py')) not in args[0]
+    assert str(use_dir / '01.py') in args[0]
+    assert str(use_dir / '02.py') not in args[0]
 
     # Test that excluding a file when its directory was passed works
     assert ament_mypy.main.main([str(use_dir), '--exclude', '02.py']) == 0
     args, _ = mock_generate_report.call_args
-    assert str(use_dir.join('01.py')) in args[0]
-    assert str(use_dir.join('02.py')) not in args[0]
+    assert str(use_dir / '01.py') in args[0]
+    assert str(use_dir / '02.py') not in args[0]
 
     # Test that an error is raised when all files are excluded
     mock_generate_report.reset_mock()
@@ -161,32 +166,32 @@ def test_main_exclude(mock_generate_report, use_dir):
     mock_generate_report.assert_not_called()
 
 
-def test_ignore(use_dir, ignore_dir):
+def test_ignore(mock_generate_report: MockType, use_dir: Path, ignore_dir: Path) -> None:
     mock_generate_report.return_value = ('', '', 0)
 
     # Test if returns no error if at least one valid dir is presented
     assert ament_mypy.main.main([str(use_dir), str(ignore_dir)]) == 0
 
 
-def test_fail(mocker, mock_mypy_generate_fail, use_dir):
+def test_fail(mocker: MockerFixture, mock_mypy_generate_fail: MockType, use_dir: Path) -> None:
     # Test if an error message from mypy causes a non-zero return
-    assert ament_mypy.main.main([str(use_dir.join('01.py'))])
+    assert ament_mypy.main.main([str(use_dir / '01.py')])
 
     # Test that a failure correctly forwards the error code out of main
     ret_val = mock_mypy_generate_fail.return_value
     test_val = 5
     mock_mypy_generate_fail.return_value = (ret_val[0], ret_val[1], test_val)
-    assert ament_mypy.main.main([str(use_dir.join('01.py'))]) == test_val
+    assert ament_mypy.main.main([str(use_dir / '01.py')]) == test_val
     test_val = 6
     mock_mypy_generate_fail.return_value = (ret_val[0], ret_val[1], test_val)
-    assert ament_mypy.main.main([str(use_dir.join('01.py'))]) == test_val
+    assert ament_mypy.main.main([str(use_dir / '01.py')]) == test_val
 
     # Test that an error code even with a blank message still gets forwarded out
     mock_mypy_generate_fail.return_value = ('', '', test_val)
-    assert ament_mypy.main.main([str(use_dir.join('01.py'))]) == test_val
+    assert ament_mypy.main.main([str(use_dir / '01.py')]) == test_val
 
 
-def test_main_error(mocker, use_dir):
+def test_main_error(mocker: MockerFixture, use_dir: Path) -> None:
     # Test if an error from mypy invocation causes a non-zero return
     mock_error = mocker.patch('ament_mypy.main._generate_mypy_report')
     mock_error.return_value = ('', 'mypy error occurred', 15)
@@ -194,58 +199,60 @@ def test_main_error(mocker, use_dir):
     assert ament_mypy.main.main([str(use_dir)]) == 15
 
 
-def test_main_config_file(mock_generate_report, mocker, use_dir):
+def test_main_config_file(mock_generate_report: MockType, mocker: MockerFixture,
+                          use_dir: Path) -> None:
     # Test that a valid config file is passed on to mypy
-    conf_file = use_dir.join('mypy.ini')
-    conf_file.write('[mypy]')
+    conf_file = use_dir / 'mypy.ini'
+    conf_file.write_text('[mypy]')
 
     mock_generate_report.return_value = ('', None, 0)
-    assert ament_mypy.main.main([str(use_dir.join('01.py')), '--config', str(conf_file)]) == 0
+    assert ament_mypy.main.main([str(use_dir / '01.py'), '--config', str(conf_file)]) == 0
     args, _ = mock_generate_report.call_args
-    assert args[1] == conf_file
+    assert args[1] == str(conf_file)
 
     # Test program handles no config file being passed correctly
-    assert ament_mypy.main.main([str(use_dir.join('01.py'))]) == 0
+    assert ament_mypy.main.main([str(use_dir / '01.py')]) == 0
     args, _ = mock_generate_report.call_args
     assert args[1] is not None
 
     # Test program raises error when invalid config file is presented
-    assert ament_mypy.main.main([str(use_dir.join('01.py')),
+    assert ament_mypy.main.main([str(use_dir / '01.py'),
                                  '--config',
-                                 str(use_dir.join('aeiou.ini'))]) == 1
+                                 str(use_dir / 'aeiou.ini')]) == 1
 
 
-def test_main_xunit(mock_mypy_generate_fail, mocker, use_dir):
+def test_main_xunit(mock_mypy_generate_fail: MockType, mocker: MockerFixture,
+                    use_dir: Path) -> None:
     mock_xunit = mocker.patch('ament_mypy.main._get_xunit_content')
     mock_xunit.return_value = "<?xml version='1.0' encoding='UTF-8'?></xml>\n"
 
     # Test that generating report files works
-    assert ament_mypy.main.main([str(use_dir), '--xunit-file', str(use_dir.join('testgen'))])
+    assert ament_mypy.main.main([str(use_dir), '--xunit-file', str(use_dir / 'testgen')])
     assert mock_xunit.call_args[0][1].endswith('testgen')
-    assert Path(use_dir.join('testgen')).is_file()
+    assert (use_dir / 'testgen').is_file()
 
     # Test that .xml file suffix is processed correctly
-    assert ament_mypy.main.main([str(use_dir), '--xunit-file', str(use_dir.join('testgen.xml'))])
+    assert ament_mypy.main.main([str(use_dir), '--xunit-file', str(use_dir / 'testgen.xml')])
     assert mock_xunit.call_args[0][1].endswith('testgen')
-    assert Path(use_dir.join('testgen.xml')).is_file()
+    assert (use_dir / 'testgen.xml').is_file()
 
     # Test that .xunit suffix is also handled
     assert ament_mypy.main.main([str(use_dir), '--xunit-file',
-                                 str(use_dir.join('testgen.xunit.xml'))])
+                                 str(use_dir / 'testgen.xunit.xml')])
     assert mock_xunit.call_args[0][1].endswith('testgen')
-    assert Path(use_dir.join('testgen.xunit.xml')).is_file()
+    assert (use_dir / 'testgen.xunit.xml').is_file()
 
     # Test that intermediate directories are handled
     assert ament_mypy.main.main([str(use_dir), '--xunit-file',
-                                 str(use_dir.join('testdir', 'testgen'))])
+                                 str(use_dir / 'testdir' / 'testgen')])
     assert mock_xunit.call_args[0][1].endswith('testgen')
-    assert Path(use_dir.join('testdir', 'testgen')).is_file()
+    assert (use_dir / 'testdir' / 'testgen').is_file()
 
     # Test that the errors/warnings generated are all forwarded to the xml generator
     assert len(mock_xunit.call_args[0][0]) == 4
 
 
-def test__get_xunit_content(mocker, sample_errors):
+def test__get_xunit_content(mocker: MockerFixture, sample_errors: list[str]) -> None:
     # Test that all errors are accounted for in xml
     errors = ament_mypy.main._get_errors('\n'.join(sample_errors))
     xml = ament_mypy.main._get_xunit_content(errors, 'tst',

--- a/ament_mypy/test/test_flake8.py
+++ b/ament_mypy/test/test_flake8.py
@@ -19,7 +19,7 @@ import pytest
 
 @pytest.mark.flake8
 @pytest.mark.linter
-def test_flake8():
+def test_flake8() -> None:
     rc, errors = main_with_errors(argv=[])
     assert rc == 0, \
         'Found %d code style errors / warnings:\n' % len(errors) + \

--- a/ament_mypy/test/test_mypy.py
+++ b/ament_mypy/test/test_mypy.py
@@ -16,6 +16,6 @@
 from ament_mypy.main import main
 
 
-def test_mypy():
-    rc = main(argv=['--exclude', 'test'])
+def test_mypy() -> None:
+    rc = main(argv=['--ament-strict'])
     assert rc == 0, 'Found code style errors / warnings'

--- a/ament_mypy/test/test_xmllint.py
+++ b/ament_mypy/test/test_xmllint.py
@@ -18,6 +18,6 @@ import pytest
 
 @pytest.mark.linter
 @pytest.mark.xmllint
-def test_xmllint():
+def test_xmllint() -> None:
     rc = main(argv=[])
     assert rc == 0, 'Found errors'

--- a/ament_xmllint/ament_xmllint/main.py
+++ b/ament_xmllint/ament_xmllint/main.py
@@ -22,6 +22,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from typing import Literal
 import urllib.request
 from xml.etree import ElementTree
 from xml.sax import make_parser
@@ -31,7 +32,7 @@ from xml.sax.saxutils import escape
 from xml.sax.saxutils import quoteattr
 
 
-def main(argv=sys.argv[1:]):
+def main(argv: list[str] = sys.argv[1:]) -> Literal[0, 1]:
     default_extensions = ['xml']
 
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
Currently its easy for `ament_mypy` to regress since it doesn't enforce all methods to be checked.  Starting with just `--strict` default from `mypy` for now. But will post on Zulip and Discourse in case there is another me out there who really cares about type checking. But that would likely be a follow up PR finalizing the settings.

Resolves part 2 of this list https://github.com/ros2/ros2/issues/1735#issuecomment-3238879650