### PR TITLE
[ament_mypy] Fix config for ament_cmake packages and type entrypoints

### DIFF
--- a/ament_clang_format/ament_clang_format/main.py
+++ b/ament_clang_format/ament_clang_format/main.py
@@ -19,6 +19,7 @@ import os
 import subprocess
 import sys
 import time
+from typing import Literal
 from xml.etree import ElementTree
 from xml.sax.saxutils import escape
 from xml.sax.saxutils import quoteattr
@@ -26,7 +27,7 @@ from xml.sax.saxutils import quoteattr
 import yaml
 
 
-def main(argv=sys.argv[1:]):
+def main(argv: list[str] = sys.argv[1:]) -> Literal[0, 1]:
     config_file = os.path.join(
         os.path.dirname(__file__), 'configuration', '.clang-format')
     extensions = ['c', 'cc', 'cpp', 'cxx', 'h', 'hh', 'hpp', 'hxx']

--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -24,6 +24,7 @@ import re
 import subprocess
 import sys
 import time
+from typing import Literal
 
 from xml.sax.saxutils import escape
 from xml.sax.saxutils import quoteattr
@@ -31,7 +32,7 @@ from xml.sax.saxutils import quoteattr
 import yaml
 
 
-def main(argv=sys.argv[1:]):
+def main(argv: list[str] = sys.argv[1:]) -> Literal[None, 1]:
     extensions = ['c', 'cc', 'cpp', 'cxx', 'h', 'hh', 'hpp', 'hxx']
 
     parser = argparse.ArgumentParser(

--- a/ament_copyright/ament_copyright/main.py
+++ b/ament_copyright/ament_copyright/main.py
@@ -18,6 +18,7 @@ import os
 import re
 import sys
 import time
+from typing import Literal
 from xml.sax.saxutils import escape
 from xml.sax.saxutils import quoteattr
 
@@ -36,7 +37,7 @@ from ament_copyright.parser import scan_past_empty_lines
 from ament_copyright.parser import search_copyright_information
 
 
-def main(argv=sys.argv[1:]):
+def main(argv: list[str] = sys.argv[1:]) -> Literal[0, 1]:
     extensions = [
         'c', 'cc', 'cpp', 'cxx', 'h', 'hh', 'hpp', 'hxx',
         'cmake',

--- a/ament_cppcheck/ament_cppcheck/main.py
+++ b/ament_cppcheck/ament_cppcheck/main.py
@@ -22,6 +22,7 @@ from shutil import which
 import subprocess
 import sys
 import time
+from typing import Literal
 from xml.etree import ElementTree
 from xml.sax.saxutils import escape
 from xml.sax.saxutils import quoteattr
@@ -51,7 +52,7 @@ def get_cppcheck_version(cppcheck_bin):
     return tokens[1]
 
 
-def main(argv=sys.argv[1:]):
+def main(argv: list[str] = sys.argv[1:]) -> Literal[0, 1, 108]:
     extensions = ['c', 'cc', 'cpp', 'cxx', 'h', 'hh', 'hpp', 'hxx']
 
     parser = argparse.ArgumentParser(

--- a/ament_cpplint/ament_cpplint/main.py
+++ b/ament_cpplint/ament_cpplint/main.py
@@ -21,6 +21,7 @@ import os
 import re
 import sys
 import time
+from typing import Literal
 from xml.sax.saxutils import escape
 from xml.sax.saxutils import quoteattr
 
@@ -69,7 +70,7 @@ def custom_get_header_guard_cpp_variable(filename):
 cpplint.GetHeaderGuardCPPVariable = custom_get_header_guard_cpp_variable
 
 
-def main(argv=sys.argv[1:]):
+def main(argv: list[str] = sys.argv[1:]) -> Literal[0, 1]:
     extensions = ['c', 'cc', 'cpp', 'cxx']
     headers = ['h', 'hh', 'hpp', 'hxx']
 

--- a/ament_mypy/ament_mypy/configuration/ament_mypy_strict.toml
+++ b/ament_mypy/ament_mypy/configuration/ament_mypy_strict.toml
@@ -7,4 +7,4 @@ warn_unused_configs = false
 
 [[tool.mypy.overrides]]
 module = "setup"
-disable_error_code = ["import-untyped"]
+ignore_errors = true

--- a/ament_mypy/ament_mypy/configuration/ament_mypy_strict.toml
+++ b/ament_mypy/ament_mypy/configuration/ament_mypy_strict.toml
@@ -3,6 +3,8 @@ strict = true
 pretty = true
 
 # Done until rhel has types-setuptools
+warn_unused_configs = false
+
 [[tool.mypy.overrides]]
 module = "setup"
-ignore_errors = true
+ignore_missing_imports = true

--- a/ament_mypy/ament_mypy/configuration/ament_mypy_strict.toml
+++ b/ament_mypy/ament_mypy/configuration/ament_mypy_strict.toml
@@ -7,4 +7,4 @@ warn_unused_configs = false
 
 [[tool.mypy.overrides]]
 module = "setup"
-ignore_missing_imports = true
+disable_error_code = ["import-untyped"]

--- a/ament_pclint/ament_pclint/main.py
+++ b/ament_pclint/ament_pclint/main.py
@@ -23,12 +23,13 @@ from shutil import which
 import subprocess
 import sys
 import time
+from typing import Literal
 from xml.etree import ElementTree
 from xml.sax.saxutils import escape
 from xml.sax.saxutils import quoteattr
 
 
-def main(argv=sys.argv[1:]):
+def main(argv: list[str] = sys.argv[1:]) -> Literal[0, 1]:
     extensions = ['c', 'cc', 'cpp', 'cxx', 'c++']
 
     parser = argparse.ArgumentParser(

--- a/ament_pep257/ament_pep257/main.py
+++ b/ament_pep257/ament_pep257/main.py
@@ -19,6 +19,7 @@ import logging
 import os
 import sys
 import time
+from typing import Literal
 from xml.sax.saxutils import escape
 from xml.sax.saxutils import quoteattr
 
@@ -55,7 +56,7 @@ _ament_ignore = [
 ]
 
 
-def main(argv=sys.argv[1:]):
+def main(argv: list[str] = sys.argv[1:]) -> Literal[0, 1]:
     parser = argparse.ArgumentParser(
         description='Check docstrings against the style conventions in PEP 257.',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)

--- a/ament_pycodestyle/ament_pycodestyle/main.py
+++ b/ament_pycodestyle/ament_pycodestyle/main.py
@@ -17,13 +17,14 @@
 import argparse
 import os
 import sys
+from typing import Literal
 from xml.sax.saxutils import escape
 from xml.sax.saxutils import quoteattr
 
 import pycodestyle
 
 
-def main(argv=sys.argv[1:]):
+def main(argv: list[str] = sys.argv[1:]) -> Literal[0, 1]:
     config_file = os.path.join(
         os.path.dirname(__file__), 'configuration', 'ament_pycodestyle.ini')
 

--- a/ament_pyflakes/ament_pyflakes/main.py
+++ b/ament_pyflakes/ament_pyflakes/main.py
@@ -18,6 +18,7 @@ import argparse
 import os
 import sys
 import time
+from typing import Literal
 from xml.sax.saxutils import escape
 from xml.sax.saxutils import quoteattr
 
@@ -26,7 +27,7 @@ from pyflakes.messages import Message
 from pyflakes.reporter import Reporter
 
 
-def main(argv=sys.argv[1:]):
+def main(argv: list[str] = sys.argv[1:]) -> Literal[0, 1]:
     parser = argparse.ArgumentParser(
         description='Check code using pyflakes.',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)

--- a/ament_uncrustify/ament_uncrustify/main.py
+++ b/ament_uncrustify/ament_uncrustify/main.py
@@ -27,11 +27,12 @@ import subprocess
 import sys
 import tempfile
 import time
+from typing import Literal
 from xml.sax.saxutils import escape
 from xml.sax.saxutils import quoteattr
 
 
-def main(argv=sys.argv[1:]):
+def main(argv: list[str] = sys.argv[1:]) -> Literal[0, 1]:
     uncrustify_bin = find_executable('uncrustify')
     if not uncrustify_bin:
         print("Could not find 'uncrustify' executable", file=sys.stderr)


### PR DESCRIPTION
It emits a warning  for warning unused configuration since they don't have setup.py. Which causes ament_mypy to register it as error. Also adds types to all entrypoints.