### PR TITLE
Allow unused ignores in `--ament-strict`

### DIFF
--- a/ament_mypy/ament_mypy/configuration/ament_mypy_strict.toml
+++ b/ament_mypy/ament_mypy/configuration/ament_mypy_strict.toml
@@ -2,6 +2,10 @@
 strict = true
 pretty = true
 
+# Done since rhel is currently 1 major and 9 minor version behind
+# We can reconsider in rhel10 when the difference is 4 minor versions.
+warn_unused_ignores = false
+
 # Done until rhel has types-setuptools
 warn_unused_configs = false
 


### PR DESCRIPTION
`mypy's` version on rhel is currently 1 major and 9 minor versions the version on Ubuntu so several things need to be type ignored on rhel but, work just fine Ubuntu. We can revisit after rhel10 and Ubuntu 26 are the new default since they only have a difference of 4 minor versions.