### PR TITLE
Fix ament_clang_format output with empty files

### DIFF
--- a/ament_clang_format/ament_clang_format/main.py
+++ b/ament_clang_format/ament_clang_format/main.py
@@ -120,8 +120,20 @@ def main(argv: list[str] = sys.argv[1:]) -> Literal[0, 1]:
         report[filename] = []
 
     xmls = output.split(b"<?xml version='1.0'?>")[1:]
+    if len(files) > len(xmls):
+        # Skip empty files since clang-format doesn't output anything for them.
+        for index in range(len(files)):
+            if os.stat(files[index]).st_size == 0:
+                xmls.insert(index, None)
+
     changed_files = []
     for filename, xml in zip(files, xmls):
+        if not xml:
+            print("Skipping empty file '%s'" % filename)
+            if not args.reformat:
+                print('')
+            continue
+
         try:
             root = ElementTree.fromstring(xml)
         except ElementTree.ParseError as e:

--- a/ament_clang_format/test/test_empty_files.py
+++ b/ament_clang_format/test/test_empty_files.py
@@ -1,0 +1,54 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_clang_format.main import main
+
+
+EMPTY_CONTENTS = ''
+PROPER_CONTENTS = '#include <this/file/should/be/unchanged>\n'
+MALFORMED_CONTENTS_BEFORE = 'void this_should_get_formatted(     );\n'
+MALFORMED_CONTENTS_AFTER = 'void this_should_get_formatted();\n'
+
+
+def test_empty_files(tmp_path, capsys):
+    """Check that formatting suggestions are correct in the presence of an empty file."""
+    empty_path = tmp_path / 'empty.cpp'
+    proper_path = tmp_path / 'proper.cpp'
+    malformed_path = tmp_path / 'malformed.cpp'
+
+    empty_path.write_text(EMPTY_CONTENTS, encoding='utf_8')
+    proper_path.write_text(PROPER_CONTENTS, encoding='utf_8')
+    malformed_path.write_text(MALFORMED_CONTENTS_BEFORE, encoding='utf_8')
+
+    main([str(empty_path), str(proper_path), str(malformed_path)])
+
+    captured = capsys.readouterr()
+    assert MALFORMED_CONTENTS_AFTER in captured.err
+
+
+def test_empty_files_reformat(tmp_path):
+    """Check that reformatting applies correctly in the presence of an empty file."""
+    empty_path = tmp_path / 'empty.cpp'
+    proper_path = tmp_path / 'proper.cpp'
+    malformed_path = tmp_path / 'malformed.cpp'
+
+    empty_path.write_text(EMPTY_CONTENTS, encoding='utf_8')
+    proper_path.write_text(PROPER_CONTENTS, encoding='utf_8')
+    malformed_path.write_text(MALFORMED_CONTENTS_BEFORE, encoding='utf_8')
+
+    main(['--reformat', str(empty_path), str(proper_path), str(malformed_path)])
+
+    assert empty_path.read_text(encoding='utf_8') == EMPTY_CONTENTS
+    assert proper_path.read_text(encoding='utf_8') == PROPER_CONTENTS
+    assert malformed_path.read_text(encoding='utf_8') == MALFORMED_CONTENTS_AFTER


### PR DESCRIPTION
Clang format doesn't output anything for empty files that are passed to it. This means an empty source code file causes our file indices to get offset from the parsed replacements, resulting in the printed replacements being generated for the wrong file. This behaviour has been verified on `clang-format` versions 10–21. (This doesn't impact the correctness of the `--reformat` option, only the correctness of the rendered output without that flag.)

This change detects empty files and fixes the indices accordingly. It also outputs a special output for them.

### Example:
Files:
```
// malformed.cpp
void this_should_get_formatted(     );
```
```
// proper.cpp
#include <but/this/file/gets/output/instead>
```
```
// empty.cpp (must have size 0)
```

#### Before this change:

```
$ ament_clang_format test/empty.cpp test/proper.cpp test/malformed.cpp 
No code style divergence in file 'test/empty.cpp'

Code style divergence in file 'test/proper.cpp':

[test/proper.cpp:1:31]: Replace [tput/] with []
- #include <but/this/file/gets/output/instead>
+ #include <but/this/file/gets/ouinstead>

1 files with 1 code style divergences
```

#### After this change:

```
$ ament_clang_format test/empty.cpp test/proper.cpp test/malformed.cpp 
Skipping empty file 'test/empty.cpp'

No code style divergence in file 'test/proper.cpp'

Code style divergence in file 'test/malformed.cpp':

[test/malformed.cpp:1:31]: Replace [     ] with []
- void this_should_get_formatted(     );
+ void this_should_get_formatted();

1 files with 1 code style divergences
```