### PR TITLE
[ament_clang_tidy] exclude rclcpp_components/node_main_* files

### DIFF
--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -163,6 +163,9 @@ def main(argv: list[str] = sys.argv[1:]) -> Literal[None, 1]:
         def is_unittest_source(package, file_path):
             return ('%s/test/' % package) in file_path
 
+        def is_rclcpp_components_generated(file_path):
+            return 'rclcpp_components/node_main_' in file_path
+
         def start_subprocess(full_cmd):
             output = ''
             try:
@@ -190,6 +193,13 @@ def main(argv: list[str] = sys.argv[1:]) -> Literal[None, 1]:
             # exclude unit test sources from being checked by clang-tidy
             # because gtest macros are problematic
             if is_unittest_source(package_name, item['file']):
+                continue
+
+            # exclude auto-generated rclcpp_components node main wrappers
+            # rclcpp_components_register_node() generates node_main_*.cpp in
+            # the build directory. These files contain "using namespace"
+            # directives that cannot be annotated with NOLINT.
+            if is_rclcpp_components_generated(item['file']):
                 continue
 
             files.append(item['file'])


### PR DESCRIPTION
Now ament_clang_tidy tests rclcpp_components generated file. It failes like

```
build/g1_hardware/Testing/20260601-0158/Test.xml: 6 tests, 0 errors, 1 failure, 0 skipped
- clang_tidy
  <<< failure message
    -- run_test.py: invoking following command in '/home/obinata/ros/colcon_ws/src/g1_ros/g1_hardware':
     - /opt/ros/jazzy/bin/ament_clang_tidy --xunit-file /home/obinata/ros/colcon_ws/build/g1_hardware/test_results/g1_hardware/clang_tidy.xunit.xml /home/obinata/ros/colcon_ws/build/g1_hardware --config .clang-tidy
    found compilation database for package 'g1_hardware' at '/home/obinata/ros/colcon_ws/build/g1_hardware/compile_commands.json'
    /home/obinata/ros/colcon_ws/build/g1_hardware/rclcpp_components/node_main_loco_cmd_adapter_node.cpp:27:1: warning: do not use namespace using-directives; use using-declarations instead [google-build-using-namespace]
       27 | using namespace rclcpp::executors;
          | ^
    /home/obinata/ros/colcon_ws/build/g1_hardware/rclcpp_components/node_main_loco_cmd_adapter_node.cpp:28:1: warning: do not use namespace using-directives; use using-declarations instead [google-build-using-namespace]
       28 | using namespace rclcpp::experimental::executors;
          | ^

    -- run_test.py: return code 0
    -- run_test.py: verify result file '/home/obinata/ros/colcon_ws/build/g1_hardware/test_results/g1_hardware/clang_tidy.xunit.xml'
  >>>
build/g1_hardware/test_results/g1_hardware/clang_tidy.xunit.xml: 5 tests, 0 errors, 2 failures, 0 skipped
- g1_hardware.clang_tidy /home/obinata/ros/colcon_ws/build/g1_hardware/rclcpp_components/node_main_loco_cmd_adapter_node.cpp:27:1
  <<< failure message
    do not use namespace using-directives; use using-declarations instead [google-build-using-namespace]
  >>>
- g1_hardware.clang_tidy /home/obinata/ros/colcon_ws/build/g1_hardware/rclcpp_components/node_main_loco_cmd_adapter_node.cpp:28:1
  <<< failure message
    do not use namespace using-directives; use using-declarations instead [google-build-using-namespace]
  >>>
```

This PR fixes it