### PR TITLE
ament_flake8: disable multiprocessing on Windows

### DIFF
--- a/ament_flake8/ament_flake8/main.py
+++ b/ament_flake8/ament_flake8/main.py
@@ -257,6 +257,8 @@ def generate_flake8_report(config_file, paths, excludes, max_line_length=None):
         excludes.extend(opts.exclude)
 
     flake8_argv = []
+    if sys.platform == 'win32':
+        flake8_argv.append('--jobs=1')
     if config_file is not None:
         flake8_argv.append('--config={0}'.format(config_file))
     if len(excludes) > 0:


### PR DESCRIPTION
On Windows under Python 3.14, `ament_flake8` hangs. flake8 runs its checks in a `multiprocessing.Pool`, and on Windows those children are spawned, not forked, so each one has to re-import flake8 and its plugins from scratch. That re-import fails inside the pool — `pyflakes` never loads, `flake8.checker._mp_plugins` is left unset, and the resulting `NameError` and the error raised while handling it chase each other in a loop instead of terminating. The failure showed up as `OSError: [WinError 10106]` out of `asyncio.windows_events` importing `_overlapped`.

flake8 gains nothing from a process pool for the file counts a single ROS package presents, and on Windows the spawn overhead makes it a loss even when it works, so this just passes `--jobs=1` there.

Needed to move ROS 2 Rolling's Windows environment to Python 3.14: ros2/ros2#1834.

Related upstream context:
- https://github.com/python/cpython/issues/118234
- https://github.com/PyCQA/flake8/commit/628aece714c9265e8def265f5fcc574605aca524 (unreleased; addresses the `NameError` symptom, not the failing import)
