### PR TITLE
Report every file checked by ament_xmllint

### DIFF
--- a/ament_xmllint/ament_xmllint/main.py
+++ b/ament_xmllint/ament_xmllint/main.py
@@ -74,7 +74,8 @@ def main(argv: list[str] = sys.argv[1:]) -> Literal[0, 1]:
 
     xmllint_bin = shutil.which('xmllint')
     if not xmllint_bin:
-        return "Could not find 'xmllint' executable"
+        print("Could not find 'xmllint' executable", file=sys.stderr)
+        return 1
 
     report = []
 
@@ -119,8 +120,8 @@ def main(argv: list[str] = sys.argv[1:]) -> Literal[0, 1]:
             else:
                 errors = None
 
-        filename = os.path.relpath(filename, start=os.getcwd())
-        report.append((filename, errors))
+            filename = os.path.relpath(filename, start=os.getcwd())
+            report.append((filename, errors))
 
     for (filename, errors) in report:
         if errors is not None:

--- a/ament_xmllint/test/test_main.py
+++ b/ament_xmllint/test/test_main.py
@@ -1,0 +1,56 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the ament_xmllint entry point."""
+
+import shutil
+
+from ament_xmllint.main import main
+import pytest
+
+
+VALID_XML = '<root><child/></root>\n'
+INVALID_XML = '<root><child></root>\n'
+
+requires_xmllint = pytest.mark.skipif(
+    shutil.which('xmllint') is None, reason="requires the 'xmllint' executable")
+
+
+@requires_xmllint
+def test_invalid_file_is_reported_when_checked_first(tmp_path, monkeypatch):
+    """Check that an invalid file is reported even when it is not checked last."""
+    (tmp_path / 'a_invalid.xml').write_text(INVALID_XML)
+    (tmp_path / 'b_valid.xml').write_text(VALID_XML)
+    monkeypatch.chdir(tmp_path)
+
+    assert main(argv=[]) == 1
+
+
+@requires_xmllint
+def test_valid_files_pass(tmp_path, monkeypatch):
+    """Check that a directory containing only valid files passes."""
+    (tmp_path / 'a_valid.xml').write_text(VALID_XML)
+    (tmp_path / 'b_valid.xml').write_text(VALID_XML)
+    monkeypatch.chdir(tmp_path)
+
+    assert main(argv=[]) == 0
+
+
+def test_missing_xmllint_returns_error_code(tmp_path, monkeypatch):
+    """Check that a missing xmllint executable yields an error code, not a string."""
+    (tmp_path / 'a_valid.xml').write_text(VALID_XML)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(shutil, 'which', lambda name: None)
+
+    assert main(argv=[]) == 1


### PR DESCRIPTION
`report.append((filename, errors))` and the `os.path.relpath` line above it sit outside the `for filename in files:` loop, so `report` only ever receives the last file that was checked and xmllint errors in every other file are silently discarded — the linter returns 0 for genuinely invalid XML. This was introduced by #570, which wrapped the loop in a `TemporaryDirectory` and re-indented the `for` statement without re-indenting the tail of its body; both lines move back inside the loop here.

This also fixes a second, smaller bug in the same function: `main()` is annotated `-> Literal[0, 1]` but returns a string when xmllint is not installed, which reaches callers as the confusing `assert "Could not find 'xmllint' executable" == 0`. It now prints to stderr and returns 1, matching the `'No files found'` branch above it.