### PR TITLE
Fix executable lookup on Windows

### DIFF
--- a/ament_clang_format/ament_clang_format/main.py
+++ b/ament_clang_format/ament_clang_format/main.py
@@ -16,6 +16,7 @@
 
 import argparse
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -247,12 +248,10 @@ def main(argv: list[str] = sys.argv[1:]) -> Literal[0, 1]:
 
 
 def find_executable(file_names):
-    paths = os.getenv('PATH').split(os.path.pathsep)
     for file_name in file_names:
-        for path in paths:
-            file_path = os.path.join(path, file_name)
-            if os.path.isfile(file_path) and os.access(file_path, os.X_OK):
-                return file_path
+        file_path = shutil.which(file_name)
+        if file_path:
+            return file_path
     return None
 
 

--- a/ament_clang_format/test/test_main.py
+++ b/ament_clang_format/test/test_main.py
@@ -1,0 +1,29 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import call
+from unittest.mock import patch
+
+from ament_clang_format.main import find_executable
+
+
+def test_find_executable_uses_platform_lookup():
+    executable = r'C:\tools\clang-format.exe'
+    with patch(
+        'ament_clang_format.main.shutil.which',
+        side_effect=[executable],
+    ) as which:
+        assert find_executable(['clang-format']) == executable
+
+    assert which.call_args_list == [call('clang-format')]

--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -21,6 +21,7 @@ import json
 from multiprocessing.pool import ThreadPool
 import os
 import re
+import shutil
 import subprocess
 import sys
 import time
@@ -267,12 +268,10 @@ def main(argv: list[str] = sys.argv[1:]) -> Literal[None, 1]:
 
 
 def find_executable(file_names):
-    paths = os.getenv('PATH').split(os.path.pathsep)
     for file_name in file_names:
-        for path in paths:
-            file_path = os.path.join(path, file_name)
-            if os.path.isfile(file_path) and os.access(file_path, os.X_OK):
-                return file_path
+        file_path = shutil.which(file_name)
+        if file_path:
+            return file_path
     return None
 
 

--- a/ament_clang_tidy/test/test_main.py
+++ b/ament_clang_tidy/test/test_main.py
@@ -1,0 +1,29 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import call
+from unittest.mock import patch
+
+from ament_clang_tidy.main import find_executable
+
+
+def test_find_executable_uses_platform_lookup():
+    executable = r'C:\tools\clang-tidy.exe'
+    with patch(
+        'ament_clang_tidy.main.shutil.which',
+        side_effect=[executable],
+    ) as which:
+        assert find_executable(['clang-tidy']) == executable
+
+    assert which.call_args_list == [call('clang-tidy')]


### PR DESCRIPTION
## Summary

Fix executable lookup on Windows in `ament_clang_tidy` and `ament_clang_format`.

Both packages manually searched `PATH` and checked the candidate filename literally. On Windows, this failed to find executables such as `clang-tidy.exe` and `clang-format.exe` when invoked without the `.exe` extension.

This change uses `shutil.which()`, which performs platform-aware executable lookup and honors Windows `PATHEXT`.

## Changes

- Replace the custom `find_executable()` implementation in `ament_clang_tidy` with `shutil.which()`.
- Replace the custom `find_executable()` implementation in `ament_clang_format` with `shutil.which()`.
- Add regression tests for both packages.

## Validation

The lookup was also verified directly on Windows:

```pwsh
>> python -c "from ament_clang_tidy.main import find_executable; print(find_executable(['clang-tidy']))"
C:\pixi_ws\ros2-windows\.pixi\envs\default\Library/bin\clang-tidy.EXE
>> python -c "from ament_clang_format.main import find_executable; print(find_executable(['clang-format']))"
C:\pixi_ws\ros2-windows\.pixi\envs\default\Library/bin\clang-format.EXE
```

Closes #590

