### PR TITLE
Fix unit test source detection on Windows

### DIFF
--- a/ament_clang_tidy/ament_clang_tidy/main.py
+++ b/ament_clang_tidy/ament_clang_tidy/main.py
@@ -33,6 +33,12 @@ from ament_lint.filesystem_helpers import find_executable
 import yaml
 
 
+def is_unittest_source(package, file_path):
+    """Return whether a file is located in the package's test directory."""
+    normalized_file_path = file_path.replace('\\', '/')
+    return ('%s/test/' % package) in normalized_file_path
+
+
 def main(argv: list[str] = sys.argv[1:]) -> Literal[None, 1]:
     extensions = ['c', 'cc', 'cpp', 'cxx', 'h', 'hh', 'hpp', 'hxx']
 
@@ -160,9 +166,6 @@ def main(argv: list[str] = sys.argv[1:]) -> Literal[None, 1]:
                or file_name == 'gmock_main.cc' or file_name == 'gmock-all.cc':
                 return True
             return False
-
-        def is_unittest_source(package, file_path):
-            return ('%s/test/' % package) in file_path
 
         def start_subprocess(full_cmd):
             output = ''

--- a/ament_clang_tidy/test/test_execution.py
+++ b/ament_clang_tidy/test/test_execution.py
@@ -15,8 +15,19 @@
 import json
 from pathlib import Path
 
+from ament_clang_tidy.main import is_unittest_source
 from ament_clang_tidy.main import main
 from ament_lint.test_helpers import TempFileWriter
+
+
+def test_is_unittest_source():
+    package = 'ament_clang_tidy'
+    assert is_unittest_source(
+        package, r'C:\workspace\src\ament_clang_tidy\test\test_execution.cpp')
+    assert is_unittest_source(
+        package, '/workspace/src/ament_clang_tidy/test/test_execution.cpp')
+    assert not is_unittest_source(
+        package, r'C:\workspace\src\ament_clang_tidy\src\main.cpp')
 
 
 def test_clang_tidy_execution():


### PR DESCRIPTION
## Description

Fix unit test source detection on Windows in `ament_clang_tidy`.

The existing implementation searched for `package/test/` directly in the compilation database path. Since Windows paths use backslashes, unit test sources were not excluded correctly.

This change:

- Normalizes path separators before checking the unit test path.

### Did you use Generative AI?

Codex/Luna was used for invetigation, fix and creating the draft of this PR description.